### PR TITLE
 Add Fig as an installation method

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -44,6 +44,14 @@ add the following lines in your ``.zshrc`` after activating Zinit::
     zinit ice ver"stable" lucid nocd
     zinit light nojhan/liquidprompt
 
+Installation via Fig
+----------------------
+
+Install `liquidprompt` with `Fig <https://fig.io/>`_ in just one click.
+
+.. image:: https://fig.io/badges/install-with-fig.svg
+   :target: https://fig.io/plugins/other/liquidprompt
+
 Dependencies
 ============
 


### PR DESCRIPTION
We recently listed on `liquidprompt` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!