### PR TITLE
feat(VCS): display the remote repository name

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -992,6 +992,20 @@ Features
 
    .. versionadded:: 2.1
 
+.. attribute:: LP_ENABLE_VCS_REMOTE
+   :type: bool
+   :value: 0
+
+   Enable the display of the remote repository in the VCS state section.
+
+   If enabled, will display :attr:`LP_MARK_VCS_REMOTE`, followed by the remote
+   repository name.
+
+   If the remote repository has commits not pulled in the local one,
+   the mark will be showed in :attr:`LP_COLOR_COMMITS_BEHIND`.
+   If the local repository has commits not pushed to the remote one,
+   the remote name is shown in :attr:`LP_COLOR_COMMITS`.
+
 .. attribute:: LP_ENABLE_VCS_ROOT
    :type: bool
    :value: 0
@@ -1693,6 +1707,14 @@ Marks
    Mark used to indicate untracked or extra files exist in the current
    repository.
 
+.. attribute:: LP_MARK_VCS_REMOTE
+   :type: string
+   :value: "⭚"
+
+   Mark used to indicate the VCS remote repository name and status.
+
+   See :attr:`LP_ENABLE_VCS_REMOTE`.
+
 .. attribute:: LP_MARK_VCSH
    :type: string
    :value: "|"
@@ -1861,6 +1883,8 @@ Valid preset color variables are:
    Color used to indicate that the current repository has a remote tracking
    branch that has commits that the local branch does not.
 
+   May be used by :attr:`LP_ENABLE_VCS_REMOTE`.
+
 .. attribute:: LP_COLOR_COMMITS
    :type: string
    :value: $YELLOW
@@ -1868,7 +1892,7 @@ Valid preset color variables are:
    Color used to indicate that the current repository has commits on the local
    branch that the remote tracking branch does not.
 
-   Also used to color :attr:`LP_MARK_STASH`.
+   Also used to color :attr:`LP_MARK_STASH` and :attr:`LP_MARK_VCS_REMOTE`.
 
 .. attribute:: LP_COLOR_CONTAINER
    :type: string

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1006,6 +1006,8 @@ Features
    If the local repository has commits not pushed to the remote one,
    the remote name is shown in :attr:`LP_COLOR_COMMITS`.
 
+   .. versionadded:: 2.2
+
 .. attribute:: LP_ENABLE_VCS_ROOT
    :type: bool
    :value: 0
@@ -1023,7 +1025,7 @@ Features
 
    .. _Python: https://docs.python.org/tutorial/venv.html
    .. _Conda: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
- 
+
    .. versionadded:: 2.
 
 .. attribute:: LP_ENABLE_WIFI_STRENGTH
@@ -1716,6 +1718,8 @@ Marks
    Mark used to indicate the VCS remote repository name and status.
 
    See :attr:`LP_ENABLE_VCS_REMOTE`.
+
+   .. versionadded:: 2.2
 
 .. attribute:: LP_MARK_VCSH
    :type: string

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1026,8 +1026,6 @@ Features
    .. _Python: https://docs.python.org/tutorial/venv.html
    .. _Conda: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
 
-   .. versionadded:: 2.
-
 .. attribute:: LP_ENABLE_WIFI_STRENGTH
    :type: bool
    :value: 0

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1001,10 +1001,11 @@ Features
    If enabled, will display :attr:`LP_MARK_VCS_REMOTE`, followed by the remote
    repository name.
 
-   If the remote repository has commits not pulled in the local one,
-   the mark will be showed in :attr:`LP_COLOR_COMMITS_BEHIND`.
-   If the local repository has commits not pushed to the remote one,
-   the remote name is shown in :attr:`LP_COLOR_COMMITS`.
+   In the default theme, if the remote repository has commits not pulled in the
+   local branch, the mark will be showed in :attr:`LP_COLOR_COMMITS_BEHIND`. If
+   the local repository has commits not pushed to the remote branch, the remote
+   name is shown in :attr:`LP_COLOR_COMMITS`. If neither is the case, nothing
+   will be shown.
 
    .. versionadded:: 2.2
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1023,6 +1023,8 @@ Features
 
    .. _Python: https://docs.python.org/tutorial/venv.html
    .. _Conda: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
+ 
+   .. versionadded:: 2.
 
 .. attribute:: LP_ENABLE_WIFI_STRENGTH
    :type: bool

--- a/docs/functions/data/vcs.rst
+++ b/docs/functions/data/vcs.rst
@@ -16,7 +16,7 @@ See the default theme function :func:`_lp_vcs_details_color` for an example of
 this.
 
 .. function:: _lp_find_vcs() -> var:lp_vcs_type, var:lp_vcs_root, \
-   var:lp_vcs_dir, var:lp_vcs_subtype
+   var:lp_vcs_dir, var:lp_vcs_specific_dir, var:lp_vcs_subtype
 
    Returns ``true`` if the current directory is part of a version control
    repository. If not, returns ``1``. Returns the VCS type ID, subtype if one
@@ -35,10 +35,21 @@ this.
    if the database is valid or healthy. Use :func:`_lp_vcs_active` to test for
    that.
 
+   Git worktrees have two Git directories: one is the main directory in
+   *lp_vcs_dir*, which holds the DB and config. The other is the worktree
+   specific directory in *lp_vcs_specific_dir*, which holds working directory
+   specific information, like index and status like merge or rebase in
+   progress.
+
    .. note::
 
       *lp_vcs_dir* will not be set for Fossil repositories. Protect it with
       ``"${lp_vcs_dir-}"``.
+
+   .. note::
+
+      *lp_vcs_specific dir* will only be set for Git repositories. Protect it
+      with ``"${lp_vcs_specific_dir-}"``.
 
    .. note::
 
@@ -50,6 +61,9 @@ this.
    .. versionchanged:: 2.1
       Added the *lp_vcs_dir* and *lp_vcs_subtype* return values.
       Added support for checking the :envvar:`GIT_DIR` environment variable.
+
+   .. versionchanged:: 2.2
+      Added the *lp_vcs_specific_dir* return value.
 
 .. function:: _lp_are_vcs_enabled()
 

--- a/docs/functions/data/vcs.rst
+++ b/docs/functions/data/vcs.rst
@@ -150,6 +150,18 @@ this.
 
    .. versionadded:: 2.0
 
+.. function:: _lp_vcs_remote() -> var:lp_vcs_remote
+
+   Return ``true`` if the current branch is a remote tracking branch. The
+   remote name is returned in *lp_vcs_remote*.
+
+   Many VCS providers do not have such information. Currently this is only
+   implemented for Git.
+
+   Can be enabled by :attr:`LP_ENABLE_VCS_REMOTE`.
+
+   .. versionadded:: 2.2
+
 .. function:: _lp_vcs_staged_files() -> var:lp_vcs_staged_files
 
    Returns ``true`` if any staged files exist in the repository. In other words,

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -152,6 +152,7 @@ Shell essentials:
 
 Development/environments:
 
+- :attr:`LP_ENABLE_VCS_REMOTE`
 - :attr:`LP_ENV_VARS` is empty by default
   (but :attr:`LP_ENABLE_ENV_VARS` is enabled).
 - :attr:`LP_ENABLE_CMAKE`

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -71,4 +71,6 @@ virtualenv
 whitespace
 wifi
 workspace
+worktree
+worktrees
 zsh

--- a/liquidprompt
+++ b/liquidprompt
@@ -2782,6 +2782,7 @@ _lp_git_active() {
 
 # Get the branch name of the Git repo in the current directory.
 _lp_git_branch() {
+    lp_vcs_branch=""
     local branch ret
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
@@ -3461,11 +3462,11 @@ _lp_bzr_uncommitted_lines() {
 }
 
 # Bazaar does not support a staging area.
-_lp_fossil_unstaged_files() { return 2 ; }
-_lp_fossil_unstaged_lines() { return 2 ; }
-_lp_fossil_staged_files() { return 2 ; }
-_lp_fossil_staged_lines() { return 2 ; }
-_lp_fossil_remote() { return 2 ; }
+_lp_bzr_unstaged_files() { return 2 ; }
+_lp_bzr_unstaged_lines() { return 2 ; }
+_lp_bzr_staged_files() { return 2 ; }
+_lp_bzr_staged_lines() { return 2 ; }
+_lp_bzr_remote() { return 2 ; }
 
 ####################
 # Wifi link status #

--- a/liquidprompt
+++ b/liquidprompt
@@ -430,6 +430,7 @@ __lp_source_config() {
     LP_ENABLE_HG=${LP_ENABLE_HG:-1}
     LP_HG_COMMAND=${LP_HG_COMMAND:-hg}
     LP_ENABLE_BZR=${LP_ENABLE_BZR:-1}
+    LP_ENABLE_VCS_REMOTE=${LP_ENABLE_VCS_REMOTE:-0}
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
     LP_TIME_ANALOG=${LP_TIME_ANALOG:-0}
     LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-1}
@@ -490,6 +491,7 @@ __lp_source_config() {
     LP_MARK_DISABLED="${LP_MARK_DISABLED:-"⌀"}"
     LP_MARK_UNTRACKED="${LP_MARK_UNTRACKED:-"*"}"
     LP_MARK_STASH="${LP_MARK_STASH:-"+"}"
+    LP_MARK_VCS_REMOTE="${LP_MARK_VCS_REMOTE:-"⭚"}"
     LP_MARK_BRACKET_OPEN="${LP_MARK_BRACKET_OPEN:-"["}"
     LP_MARK_BRACKET_CLOSE="${LP_MARK_BRACKET_CLOSE:-"]"}"
     LP_MARK_MULTIPLEXER_OPEN="${LP_MARK_MULTIPLEXER_OPEN:-"$LP_MARK_BRACKET_OPEN"}"
@@ -2669,6 +2671,21 @@ _lp_vcs_details_color() {
         fi
     fi
 
+    if (( LP_ENABLE_VCS_REMOTE )); then
+        if _lp_vcs_remote; then
+            if [[ "$lp_vcs_commit_behind" -ne "0" ]]; then
+                lp_vcs_details_color+="${LP_COLOR_COMMITS_BEHIND}${LP_MARK_VCS_REMOTE}"
+            else
+                lp_vcs_details_color+="${NO_COL}${LP_MARK_VCS_REMOTE}"
+            fi
+            if [[ "$lp_vcs_commit_ahead" -ne "0" ]]; then
+                lp_vcs_details_color+="${LP_COLOR_COMMITS}${lp_vcs_remote}${NO_COL}"
+            else
+                lp_vcs_details_color+="${NO_COL}${lp_vcs_remote}"
+            fi
+        fi
+    fi
+
     lp_vcs_details_color+="$NO_COL"
 }
 
@@ -2747,6 +2764,11 @@ _lp_vcs_staged_files() {
 # Get the number of changed lines in staging compared to the last or checked out commit.
 _lp_vcs_staged_lines() {
     "_lp_${lp_vcs_type}_staged_lines"
+}
+
+# Get the remote name for the current branch.
+_lp_vcs_remote() {
+    "_lp_${lp_vcs_type}_remote"
 }
 
 # GIT #
@@ -2971,6 +2993,48 @@ _lp_git_staged_lines() {
     lp_vcs_staged_d_lines=$lp_git_diff_shortstat_d_lines
 }
 
+# Get the remote name for the current branch.
+# NOTE: Assumes that `_lp_find_vcs` and `_lp_vcs_branch` (costly functions) have been called.
+_lp_git_remote() {
+    lp_vcs_remote=""
+
+    # If there is no branch…
+    if [[ -z "$lp_vcs_branch" ]]; then
+        # … then there is no remote.
+        return 1
+    fi
+
+    # If we don't have a VCS root…
+    if [[ -z "$lp_vcs_root" ]]; then
+        # … we cannot find the config file.
+        return 1
+    fi
+
+    local file="${lp_vcs_root}/.git/config"
+    local delimiter=" = " # With spaces.
+    local in_branch=0
+    # We test for $line in the loop is here to ensure that we read the last line,
+    # even if the file does not ends with a \n.
+    # This bypass a known behavior of the C standard, not fixed in POSIX.
+    while IFS='' read -r line || [[ -n "$line" ]] ; do
+        # If we are in the branch config section.
+        if [[ "$line" == "[branch \"${lp_vcs_branch}\"]" ]]; then
+            in_branch=1
+        elif [[ "$line" == *"remote${delimiter}"* ]] ; then
+            if [[ "$in_branch" ]]; then
+                # Remove first part until delimiter.
+                lp_vcs_remote="${line#*"${key}${delimiter}"}"
+                return 0
+            else
+                in_branch=0
+            fi
+        fi
+    done <"$file"
+
+    # Remote not found.
+    return 1
+}
+
 # MERCURIAL #
 
 # Check if Mercurial is enabled in Liquid Prompt and the current directory is a
@@ -3087,6 +3151,8 @@ _lp_hg_unstaged_files() { return 2 ; }
 _lp_hg_unstaged_lines() { return 2 ; }
 _lp_hg_staged_files() { return 2 ; }
 _lp_hg_staged_lines() { return 2 ; }
+
+_lp_hg_remote() { return 2 ; } # FIXME This should be implemented.
 
 # SUBVERSION #
 
@@ -3293,6 +3359,7 @@ _lp_fossil_unstaged_files() { return 2 ; }
 _lp_fossil_unstaged_lines() { return 2 ; }
 _lp_fossil_staged_files() { return 2 ; }
 _lp_fossil_staged_lines() { return 2 ; }
+_lp_fossil_remote() { return 2 ; }
 
 # Bazaar #
 
@@ -3398,6 +3465,7 @@ _lp_fossil_unstaged_files() { return 2 ; }
 _lp_fossil_unstaged_lines() { return 2 ; }
 _lp_fossil_staged_files() { return 2 ; }
 _lp_fossil_staged_lines() { return 2 ; }
+_lp_fossil_remote() { return 2 ; }
 
 ####################
 # Wifi link status #

--- a/liquidprompt
+++ b/liquidprompt
@@ -3024,7 +3024,7 @@ _lp_git_remote() {
         elif [[ "$line" == *"remote${delimiter}"* ]] ; then
             if [[ "$in_branch" ]]; then
                 # Remove first part until delimiter.
-                lp_vcs_remote="${line#*"${key}${delimiter}"}"
+                lp_vcs_remote="${line#*"remote${delimiter}"}"
                 return 0
             else
                 in_branch=0

--- a/liquidprompt
+++ b/liquidprompt
@@ -2678,15 +2678,19 @@ _lp_vcs_details_color() {
     fi
 
     if _lp_vcs_remote; then
-        if [[ "$lp_vcs_commit_behind" -ne "0" ]]; then
-            lp_vcs_details_color+="${LP_COLOR_COMMITS_BEHIND}${LP_MARK_VCS_REMOTE}"
-        else
-            lp_vcs_details_color+="${NO_COL}${LP_MARK_VCS_REMOTE}"
-        fi
-        if [[ "$lp_vcs_commit_ahead" -ne "0" ]]; then
-            lp_vcs_details_color+="${LP_COLOR_COMMITS}${lp_vcs_remote}${NO_COL}"
-        else
-            lp_vcs_details_color+="${NO_COL}${lp_vcs_remote}"
+        # Commits behind but not ahead.
+        if   [[ "$lp_vcs_commit_behind" -ne 0 && "$lp_vcs_commit_ahead" -eq 0 ]]; then
+            lp_vcs_details_color+="${LP_COLOR_COMMITS_BEHIND}${LP_MARK_VCS_REMOTE}${lp_vcs_remote}${NO_COL}"
+
+        # Commits ahead but not behind.
+        elif [[ "$lp_vcs_commit_behind" -eq 0 && "$lp_vcs_commit_ahead" -ne 0 ]]; then
+            lp_vcs_details_color+="${LP_COLOR_COMMITS}${LP_MARK_VCS_REMOTE}${lp_vcs_remote}${NO_COL}"
+
+        # Commits both ahead and behind: the mark is colored differently.
+        elif [[ "$lp_vcs_commit_behind" -ne 0 && "$lp_vcs_commit_ahead" -ne 0 ]]; then
+            lp_vcs_details_color+="${LP_COLOR_COMMITS_BEHIND}${LP_MARK_VCS_REMOTE}${LP_COLOR_COMMITS}${lp_vcs_remote}${NO_COL}"
+
+        # else: display nothing.
         fi
     fi
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -1412,7 +1412,7 @@ _lp_path_format() {
 
     local -i path_length="${#display_path}"
 
-    local lp_vcs_root lp_vcs_dir lp_vcs_type lp_vcs_subtype
+    local lp_vcs_root lp_vcs_dir lp_vcs_specific_dir lp_vcs_type lp_vcs_subtype
     local vcs_root_directory=
     if (( LP_PATH_VCS_ROOT )) && _lp_find_vcs; then
         __lp_pwd_tilde "$lp_vcs_root"
@@ -2558,6 +2558,12 @@ _lp_find_vcs() {
     fi
 
     if [[ $lp_vcs_type == git ]]; then
+        lp_vcs_specific_dir="$lp_vcs_dir"
+        if [[ -f "${lp_vcs_dir}/gitdir" ]]; then
+            # Then this is a worktree, and the config exists two levels up.
+            lp_vcs_dir="${lp_vcs_dir}/../.."
+        fi
+
         if [[ -n "${VCSH_DIRECTORY-}" ]]; then
             lp_vcs_subtype="vcsh"
         elif [[ -d "${lp_vcs_dir}/svn" ]]; then
@@ -2817,31 +2823,31 @@ _lp_git_commit_id() {
 _lp_git_head_status() {
     local IFS="" step total
 
-    if [[ -f "${lp_vcs_dir}/MERGE_HEAD" ]]; then
+    if [[ -f "${lp_vcs_specific_dir}/MERGE_HEAD" ]]; then
         lp_vcs_head_status="MERGING"
-    elif [[ -d "${lp_vcs_dir}/rebase-merge" ]]; then
-        test -r "${lp_vcs_dir}/rebase-merge/msgnum" && read -r step <"${lp_vcs_dir}/rebase-merge/msgnum"
-        test -r "${lp_vcs_dir}/rebase-merge/end" && read -r total <"${lp_vcs_dir}/rebase-merge/end"
-        if [[ -f "${lp_vcs_dir}/rebase-merge/interactive" ]]; then
+    elif [[ -d "${lp_vcs_specific_dir}/rebase-merge" ]]; then
+        test -r "${lp_vcs_specific_dir}/rebase-merge/msgnum" && read -r step <"${lp_vcs_specific_dir}/rebase-merge/msgnum"
+        test -r "${lp_vcs_specific_dir}/rebase-merge/end" && read -r total <"${lp_vcs_specific_dir}/rebase-merge/end"
+        if [[ -f "${lp_vcs_specific_dir}/rebase-merge/interactive" ]]; then
             lp_vcs_head_status="REBASE-i"
         else
             lp_vcs_head_status="REBASE-m"
         fi
-    elif [[ -d "${lp_vcs_dir}/rebase-apply" ]]; then
-        test -r "${lp_vcs_dir}/rebase-apply/next" && read -r step <"${lp_vcs_dir}/rebase-apply/next"
-        test -r "${lp_vcs_dir}/rebase-apply/last" && read -r total <"${lp_vcs_dir}/rebase-apply/last"
-        if [[ -f "${lp_vcs_dir}/rebase-apply/rebasing" ]]; then
+    elif [[ -d "${lp_vcs_specific_dir}/rebase-apply" ]]; then
+        test -r "${lp_vcs_specific_dir}/rebase-apply/next" && read -r step <"${lp_vcs_specific_dir}/rebase-apply/next"
+        test -r "${lp_vcs_specific_dir}/rebase-apply/last" && read -r total <"${lp_vcs_specific_dir}/rebase-apply/last"
+        if [[ -f "${lp_vcs_specific_dir}/rebase-apply/rebasing" ]]; then
             lp_vcs_head_status="REBASE"
-        elif [[ -f "${lp_vcs_dir}/rebase-apply/applying" ]]; then
+        elif [[ -f "${lp_vcs_specific_dir}/rebase-apply/applying" ]]; then
             lp_vcs_head_status="AM"
         else
             lp_vcs_head_status="AM/REBASE"
         fi
-    elif [[ -f "${lp_vcs_dir}/CHERRY_PICK_HEAD" ]]; then
+    elif [[ -f "${lp_vcs_specific_dir}/CHERRY_PICK_HEAD" ]]; then
         lp_vcs_head_status="CHERRY-PICKING"
-    elif [[ -f "${lp_vcs_dir}/REVERT_HEAD" ]]; then
+    elif [[ -f "${lp_vcs_specific_dir}/REVERT_HEAD" ]]; then
         lp_vcs_head_status="REVERTING"
-    elif [[ -f "${lp_vcs_dir}/BISECT_START" ]]; then
+    elif [[ -f "${lp_vcs_specific_dir}/BISECT_START" ]]; then
         lp_vcs_head_status="BISECTING"
     else
         return 1
@@ -2999,19 +3005,17 @@ _lp_git_staged_lines() {
 _lp_git_remote() {
     lp_vcs_remote=""
 
-    # If there is no branch…
     if [[ -z "$lp_vcs_branch" ]]; then
-        # … then there is no remote.
+        # There is no remote.
         return 1
     fi
 
-    # If we don't have a VCS root…
-    if [[ -z "$lp_vcs_root" ]]; then
-        # … we cannot find the config file.
+    if [[ -z "$lp_vcs_dir" ]]; then
+        # Cannot find the config file.
         return 1
     fi
 
-    local file="${lp_vcs_root}/.git/config"
+    local file="${lp_vcs_dir}/config"
     local delimiter=" = " # With spaces.
     local in_branch=0
     # We test for $line in the loop is here to ensure that we read the last line,

--- a/liquidprompt
+++ b/liquidprompt
@@ -2677,18 +2677,16 @@ _lp_vcs_details_color() {
         fi
     fi
 
-    if (( LP_ENABLE_VCS_REMOTE )); then
-        if _lp_vcs_remote; then
-            if [[ "$lp_vcs_commit_behind" -ne "0" ]]; then
-                lp_vcs_details_color+="${LP_COLOR_COMMITS_BEHIND}${LP_MARK_VCS_REMOTE}"
-            else
-                lp_vcs_details_color+="${NO_COL}${LP_MARK_VCS_REMOTE}"
-            fi
-            if [[ "$lp_vcs_commit_ahead" -ne "0" ]]; then
-                lp_vcs_details_color+="${LP_COLOR_COMMITS}${lp_vcs_remote}${NO_COL}"
-            else
-                lp_vcs_details_color+="${NO_COL}${lp_vcs_remote}"
-            fi
+    if _lp_vcs_remote; then
+        if [[ "$lp_vcs_commit_behind" -ne "0" ]]; then
+            lp_vcs_details_color+="${LP_COLOR_COMMITS_BEHIND}${LP_MARK_VCS_REMOTE}"
+        else
+            lp_vcs_details_color+="${NO_COL}${LP_MARK_VCS_REMOTE}"
+        fi
+        if [[ "$lp_vcs_commit_ahead" -ne "0" ]]; then
+            lp_vcs_details_color+="${LP_COLOR_COMMITS}${lp_vcs_remote}${NO_COL}"
+        else
+            lp_vcs_details_color+="${NO_COL}${lp_vcs_remote}"
         fi
     fi
 
@@ -2774,6 +2772,7 @@ _lp_vcs_staged_lines() {
 
 # Get the remote name for the current branch.
 _lp_vcs_remote() {
+    (( LP_ENABLE_VCS_REMOTE )) || return 2
     "_lp_${lp_vcs_type}_remote"
 }
 
@@ -3251,6 +3250,8 @@ _lp_svn_unstaged_files() { return 2 ; }
 _lp_svn_unstaged_lines() { return 2 ; }
 _lp_svn_staged_files() { return 2 ; }
 _lp_svn_staged_lines() { return 2 ; }
+# Subversion does not have remotes.
+_lp_svn_remote() { return 2 ; }
 
 # FOSSIL #
 

--- a/tests/test_git.sh
+++ b/tests/test_git.sh
@@ -18,6 +18,9 @@ function test_git {
     LP_ENABLE_VCS_ROOT=0
     LP_ENABLE_VCS_REMOTE=1
 
+    PS1=""
+    lp_activate
+
     wd="${SHUNIT_TMPDIR}/test_remote/"
     mkdir -p "$wd"
     cd "$wd"
@@ -26,27 +29,31 @@ function test_git {
     assertTrue "VCS are enabled here." "$?"
 
     git init
+    # We need a commit to have a branch that can have a remote.
+    touch test
+    git add test
+    git commit -m "test"
+    # Ensure we use "main" and not "master".
+    git branch -m main
 
     _lp_find_vcs
     assertTrue "We detect a VCS updir." "$?"
     assertEquals "We found a Git repo." "git" "$lp_vcs_type"
-    assertEquals "We see the repo." "$wd" "$lp_vcs_root"
+    assertEquals "We see the repo." "$wd" "$lp_vcs_root/"
 
     _lp_vcs_active
     assertTrue "Git detects the repository." "$?"
 
-    _lp_vcs_branch
-    assertEquals "Default branch is master." "master" "$lp_vcs_branch"
-
-    git branch -m notsomain
+    git checkout -b notsomain
 
     _lp_vcs_branch
     assertEquals "Branch change is detected." "notsomain" "$lp_vcs_branch"
 
-    git remote add notsoremote git@nojhan.github:nojhan/liquidprompt.git
+    # Use a local remote or else one could have problems.
+    git branch -u main
 
     _lp_git_remote
-    assetEquals "Remote is found." "notsoremote." "$lp_vcs_remote"
+    assertEquals "Remote is found." "." "$lp_vcs_remote"
 }
 
 . ./shunit2

--- a/tests/test_git.sh
+++ b/tests/test_git.sh
@@ -1,0 +1,52 @@
+
+# Error on unset variables
+set -u
+
+if [ -n "${ZSH_VERSION-}" ]; then
+  SHUNIT_PARENT="$0"
+  setopt shwordsplit
+fi
+
+. ../liquidprompt --no-activate
+
+function test_git {
+
+    LP_ENABLE_GIT=1
+    LP_ENABLE_FOSSIL=0
+    LP_ENABLE_SVN=0
+    LP_ENABLE_BZR=0
+    LP_ENABLE_VCS_ROOT=0
+    LP_ENABLE_VCS_REMOTE=1
+
+    wd="${SHUNIT_TMPDIR}/test_remote/"
+    mkdir -p "$wd"
+    cd "$wd"
+
+    _lp_are_vcs_enabled
+    assertTrue "VCS are enabled here." "$?"
+
+    git init
+
+    _lp_find_vcs
+    assertTrue "We detect a VCS updir." "$?"
+    assertEquals "We found a Git repo." "git" "$lp_vcs_type"
+    assertEquals "We see the repo." "$wd" "$lp_vcs_root"
+
+    _lp_vcs_active
+    assertTrue "Git detects the repository." "$?"
+
+    _lp_vcs_branch
+    assertEquals "Default branch is master." "master" "$lp_vcs_branch"
+
+    git branch -m notsomain
+
+    _lp_vcs_branch
+    assertEquals "Branch change is detected." "notsomain" "$lp_vcs_branch"
+
+    git remote add notsoremote git@nojhan.github:nojhan/liquidprompt.git
+
+    _lp_git_remote
+    assetEquals "Remote is found." "notsoremote." "$lp_vcs_remote"
+}
+
+. ./shunit2

--- a/tests/test_git.sh
+++ b/tests/test_git.sh
@@ -32,7 +32,7 @@ function test_git {
     # We need a commit to have a branch that can have a remote.
     touch test
     git add test
-    git commit -m "test"
+    git commit -m "test" --author="A U Thor <author@example.com>" --no-verify --no-gpg-sign
     # Ensure we use "main" and not "master".
     git branch -m main
 

--- a/tests/test_git.sh
+++ b/tests/test_git.sh
@@ -29,10 +29,12 @@ function test_git {
     assertTrue "VCS are enabled here." "$?"
 
     git init
+    git config --local user.email "author@example.com"
+    git config --local user.name "A U Thor"
     # We need a commit to have a branch that can have a remote.
     touch test
     git add test
-    git commit -m "test" --author="A U Thor <author@example.com>" --no-verify --no-gpg-sign
+    git commit -m "test" --no-verify --no-gpg-sign
     # Ensure we use "main" and not "master".
     git branch -m main
 

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -153,7 +153,7 @@ function test_pwd_tilde {
 }
 
 function pathSetUp {
-  # We cannot use SHUNIT_TEMPDIR because we need to know the start of the path
+  # We cannot use SHUNIT_TMPDIR because we need to know the start of the path
   typeset long_path="/tmp/_lp/a/very/long/pathname"
   mkdir -p "${long_path}/" "${long_path/name/foo}/"
 }


### PR DESCRIPTION
- Only if LP_ENABLE_VCS_REMOTE is enabled (disabled by default, as the function parses a file and the output takes some room).
- Introduces LP_MARK_VCS_REMOTE.
- Re-use LP_COLOR_COMMITS and LP_COLOR_COMMITS_BEHIND.

Refs: #782