### PR TITLE
Fix RAM display on non-Linux hosts

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -3795,6 +3795,9 @@ case "$LP_OS" in
                 fi
             # Assumes file exists.
             done < "$_LP_LINUX_RAM_FILE"
+            # Values in file are in KiB.
+            lp_ram_total_bytes=$(( lp_ram_total_bytes * 1024 ))
+            lp_ram_avail_bytes=$(( lp_ram_avail_bytes * 1024 ))
             # Used memory may be used in a theme.
             # shellcheck disable=SC2034
             lp_ram_used_bytes=$((lp_ram_total_bytes-lp_ram_avail_bytes))
@@ -3874,16 +3877,15 @@ _lp_ram() {
     __lp_ram_bytes || return "$?"
     # Now we have: lp_ram_avail_bytes, lp_ram_total_bytes, lp_ram_used_bytes.
 
-    lp_ram=
     lp_ram_human=
     lp_ram_perc=
 
-    lp_ram=$(( lp_ram_avail_bytes * 1024 )) # in KiB
+    lp_ram=$(( lp_ram_avail_bytes / 1024 )) # in KiB
     lp_ram_perc=$(( 100 * lp_ram_avail_bytes / lp_ram_total_bytes ))
 
     if (( lp_ram <= LP_RAM_THRESHOLD || lp_ram_perc <= LP_RAM_THRESHOLD_PERC )); then
         local lp_bytes lp_bytes_units
-        __lp_bytes_to_human "${lp_ram}" "$LP_RAM_PRECISION"
+        __lp_bytes_to_human "${lp_ram_avail_bytes}" "$LP_RAM_PRECISION"
         lp_ram_human="${lp_bytes}"
         lp_ram_human_units="${lp_bytes_units}"
         return 0

--- a/tests/test_ram.sh
+++ b/tests/test_ram.sh
@@ -16,8 +16,8 @@ typeset -a os outputs values_avail values_total
 os+=('Linux')
 outputs+=('MemTotal: 2048 kB
 MemAvailable: 1024 kB')
-values_avail+=('1024')
-values_total+=('2048')
+values_avail+=('1048576')
+values_total+=('2097152')
 
 # Linux 5.4.0-139-generic #156-Ubuntu SMP Fri Jan 20 17:27:18 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
 os+=('Linux')
@@ -76,8 +76,8 @@ DirectMap2M:     7710720 kB
 DirectMap1G:     1048576 kB
 '
 )
-values_avail+=('6899116')
-values_total+=('8033668')
+values_avail+=('7064694784')
+values_total+=('8226476032')
 
 
 # (Free?)BSD, unknown version
@@ -133,7 +133,7 @@ function test_ram() {
 
     # Iterate over tests.
     for (( i=0; i < ${#values_avail[@]}; i++ )); do
-        # Load Linux version.
+        # Load correct version for OS.
         uname() { printf "${os[$i]}"; }
         . ../liquidprompt --no-activate
         unset -f uname


### PR DESCRIPTION
A number of small bugs that worked together to make Linux RAM display correct, but MacOS and BSD off by a factor of 1024.

Fixes #787

Note that this was not caught by the tests, as the tests only check what `__lp_ram_bytes()` returns, not what `_lp_ram()` returns. Would be good to have that added @nojhan if you want to do that. Specifically the values of `$lp_ram` and `$lp_ram_human`.
