### PR TITLE
Add LP_THEME variable for controlling current theme

### DIFF
--- a/docs/functions/public.rst
+++ b/docs/functions/public.rst
@@ -49,9 +49,9 @@ their config.
    The optional flag ``--list`` will instead list all currently loaded
    themes.
 
-   The variable :envvar:`LP_THEME` can be set to a theme name which functions
-   like calling this function. :envvar:`LP_THEME` will always hold the
-   currently active theme; it is updated by this function. If
+   The variable :envvar:`LP_THEME` can be set to a theme name, which is
+   essentially equivalent to calling this function. :envvar:`LP_THEME` will
+   always hold the currently active theme; it is updated by this function. If
    :envvar:`LP_THEME` is set to an invalid theme name, it will be reset to the
    previous value.
 

--- a/docs/functions/public.rst
+++ b/docs/functions/public.rst
@@ -49,9 +49,18 @@ their config.
    The optional flag ``--list`` will instead list all currently loaded
    themes.
 
+   The variable :envvar:`LP_THEME` can be set to a theme name which functions
+   like calling this function. :envvar:`LP_THEME` will always hold the
+   currently active theme; it is updated by this function. If
+   :envvar:`LP_THEME` is set to an invalid theme name, it will be reset to the
+   previous value.
+
    This function supports shell autocompletion.
 
    .. versionadded:: 2.0
+
+   .. versionchanged:: 2.2
+      :envvar:`LP_THEME` reading and setting added.
 
 .. function:: lp_terminal_format(foreground_color, [background_color], \
                                  [bold], [underline], \

--- a/liquidprompt
+++ b/liquidprompt
@@ -4630,6 +4630,10 @@ __lp_set_prompt() {
         printf '%s' "$_LP_TI_BELL"
     fi
 
+    if [[ "$_LP_OLD_THEME" != "$LP_THEME" ]]; then
+        lp_theme "$LP_THEME" >/dev/null 2>&1
+    fi
+
     # Localize cache data variables
     local _lp_git_diff_shortstat_uncommitted _lp_git_diff_shortstat_unstaged _lp_git_diff_shortstat_staged
 
@@ -4881,10 +4885,13 @@ prompt_OFF() {
 lp_theme() {
     local theme="${1-}"
 
+    LP_THEME="$theme"
+
     if [[ $theme == '--list' ]]; then
         local -a lp_theme_list
         __lp_theme_list
         printf '%s\n' "${lp_theme_list[@]}"
+        LP_THEME="$_LP_OLD_THEME"
         return
     fi
 
@@ -4894,12 +4901,14 @@ lp_theme() {
         printf '%s\n%s\n' \
             'Must pass in the name of a theme. If you meant the default Liquid Prompt theme, try "default".' \
             'Run "lp_theme --list" to see all loaded and available themes.' 2>&1
+        LP_THEME="$_LP_OLD_THEME"
         return 1
     fi
 
     if ! __lp_is_function "$f_prompt"; then
         printf 'Loading theme "%s" failed: cannot find function "%s". Please source the theme file first.\n' \
             "$theme" "$f_prompt" 2>&1
+        LP_THEME="$_LP_OLD_THEME"
         return 2
     fi
     if ! __lp_is_function "$f_dir"; then
@@ -4912,6 +4921,7 @@ lp_theme() {
     _LP_THEME_ACTIVATE_FUNCTION=$f_activate
     _LP_THEME_DIRECTORY_FUNCTION=$f_dir
     _LP_THEME_PROMPT_FUNCTION=$f_prompt
+    _LP_OLD_THEME="$theme"
 
     "$f_activate"
     prompt_on

--- a/tests/test_lp_theme.sh
+++ b/tests/test_lp_theme.sh
@@ -1,0 +1,44 @@
+
+# Error on unset variables
+set -u
+
+if [ -n "${ZSH_VERSION-}" ]; then
+  SHUNIT_PARENT="$0"
+  setopt shwordsplit
+fi
+
+. ../liquidprompt --no-activate
+
+
+function setUp {
+  unset LP_THEME _LP_OLD_THEME _LP_THEME_ACTIVATE_FUNCTION
+
+  PS1='$ '
+  lp_activate
+}
+
+function _lp_test_theme_prompt { : ; }
+
+function test_lp_theme_function {
+  assertEquals "$LP_THEME" "default"
+
+  lp_theme test
+  assertEquals "$LP_THEME" "test"
+
+  lp_theme invalid_theme
+  assertEquals "$LP_THEME" "test"
+}
+
+function test_lp_theme_var {
+  assertEquals "$LP_THEME" "default"
+
+  LP_THEME=test
+  __lp_set_prompt
+  assertEquals "$LP_THEME" "test"
+
+  LP_THEME=invalid_theme
+  __lp_set_prompt
+  assertEquals "$LP_THEME" "test"
+}
+
+. ./shunit2


### PR DESCRIPTION
LP_THEME is always set to the currently active theme when changed by lp_theme(). It can also be assigned a theme name to have lp_theme() called automatically. This is useful for interacting with tools like direnv that cannot call shell functions since they exist in a subshell.

Closes #721