### PR TITLE
feat(config): adds missing LP_ENABLE_* variables

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -450,8 +450,9 @@ Features
    :type: bool
    :value: 1
 
-   Displays a green ``@`` if the connection has X11 support;
-   a yellow one if not.
+   Detect if the connection has X11 support.
+   
+   In the default them, display a green ``@`` if it does; a yellow one if not.
 
    See also :attr:`LP_COLOR_X11_ON` and :attr:`LP_COLOR_X11_OFF`.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -451,7 +451,7 @@ Features
    :value: 1
 
    Detect if the connection has X11 support.
-   
+
    In the default theme, display a green ``@`` if it does; a yellow one if not.
 
    See also :attr:`LP_COLOR_X11_ON` and :attr:`LP_COLOR_X11_OFF`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -352,6 +352,14 @@ Features
 
    See also: :attr:`LP_MARK_BZR`.
 
+.. attribute:: LP_ENABLE_CHROOT
+   :type: bool
+   :value: 1
+
+   Display whether a *chroot* environment is active.
+
+   .. versionadded: 2.2
+
 .. attribute:: LP_ENABLE_CMAKE
    :type: bool
    :value: 0
@@ -437,6 +445,17 @@ Features
    See also: :attr:`LP_MARK_DIRSTACK` and :attr:`LP_COLOR_DIRSTACK`.
 
    .. versionadded:: 2.0
+
+.. attribute:: LP_ENABLE_DISPLAY
+   :type: bool
+   :value: 1
+
+   Displays a green ``@`` if the connection has X11 support;
+   a yellow one if not.
+
+   See also :attr:`LP_COLOR_X11_ON` and :attr:`LP_COLOR_X11_OFF`.
+
+   .. versionadded:: 2.2
 
 .. attribute:: LP_ENABLE_DISK
    :type: bool
@@ -707,6 +726,21 @@ Features
    according to its hash, instead of using :attr:`LP_COLOR_MODULES`.
 
    See :attr:`LP_ENABLE_MODULES`.
+
+   .. versionadded:: 2.2
+
+.. attribute:: LP_ENABLE_MUX
+   :type: bool
+   :value: 1
+
+   Allows getting the name of the current multiplexer session
+   (*screen* or *tmux*).
+
+   If set to ``0``, also disables:
+
+   * :attr:`LP_COLOR_IN_MULTIPLEXER`,
+   * :attr:`LP_MARK_MULTIPLEXER_OPEN` and :attr:`LP_MARK_MULTIPLEXER_CLOSE`,
+   * :attr:`LP_ENABLE_SCREEN_TITLE` and :attr:`LP_ENABLE_TMUX_TITLE_PANES`.
 
    .. versionadded:: 2.2
 
@@ -1645,6 +1679,9 @@ Marks
 
    .. versionadded:: 2.1
 
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_MUX`.
+
 .. attribute:: LP_MARK_MULTIPLEXER_OPEN
    :type: string
    :value: $LP_MARK_BRACKET_OPEN
@@ -1655,6 +1692,9 @@ Marks
    See also: :attr:`LP_MARK_MULTIPLEXER_CLOSE`, :attr:`LP_MARK_BRACKET_OPEN`.
 
    .. versionadded:: 2.1
+
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_MUX`.
 
 .. attribute:: LP_MARK_OS
    :type: array<string>
@@ -2109,6 +2149,9 @@ Valid preset color variables are:
    Color used for :attr:`LP_MARK_MULTIPLEXER_OPEN` and
    :attr:`LP_MARK_MULTIPLEXER_CLOSE` if the terminal is in a multiplexer.
 
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_MUX`.
+
 .. attribute:: LP_COLOR_JOB_D
    :type: string
    :value: $YELLOW
@@ -2455,8 +2498,12 @@ Valid preset color variables are:
 
    Color used for indicating that a display is not connected.
 
+   See also :attr:`LP_ENABLE_DISPLAY`.
+
 .. attribute:: LP_COLOR_X11_ON
    :type: string
    :value: $GREEN
 
    Color used for indicating that a display is connected.
+
+   See also :attr:`LP_ENABLE_DISPLAY`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -730,18 +730,17 @@ Features
 
    .. versionadded:: 2.2
 
-.. attribute:: LP_ENABLE_MUX
+.. attribute:: LP_ENABLE_MULTIPLEXER
    :type: bool
    :value: 1
 
-   Allows getting the name of the current multiplexer session
-   (*screen* or *tmux*).
+   Allows getting the name of the current multiplexer
+   (*screen* or *tmux*), if any.
 
    If set to ``0``, also disables:
 
    * :attr:`LP_COLOR_IN_MULTIPLEXER`,
-   * :attr:`LP_MARK_MULTIPLEXER_OPEN` and :attr:`LP_MARK_MULTIPLEXER_CLOSE`,
-   * :attr:`LP_ENABLE_SCREEN_TITLE` and :attr:`LP_ENABLE_TMUX_TITLE_PANES`.
+   * :attr:`LP_MARK_MULTIPLEXER_OPEN` and :attr:`LP_MARK_MULTIPLEXER_CLOSE`.
 
    .. versionadded:: 2.2
 
@@ -1443,6 +1442,9 @@ Marks
 
    See also: :attr:`LP_MARK_BRACKET_OPEN`, :attr:`LP_MARK_MULTIPLEXER_CLOSE`.
 
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_MULTIPLEXER`.
+
 .. attribute:: LP_MARK_BRACKET_OPEN
    :type: string
    :value: "["
@@ -1451,6 +1453,9 @@ Marks
    enclosing user, host, and current working directory sections.
 
    See also: :attr:`LP_MARK_BRACKET_CLOSE`, :attr:`LP_MARK_MULTIPLEXER_OPEN`.
+
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_MULTIPLEXER`.
 
 .. attribute:: LP_MARK_BZR
    :type: string
@@ -1681,7 +1686,7 @@ Marks
    .. versionadded:: 2.1
 
    .. versionchanged:: 2.2
-      Can be disabled by :attr:`LP_ENABLE_MUX`.
+      Can be disabled by :attr:`LP_ENABLE_MULTIPLEXER`.
 
 .. attribute:: LP_MARK_MULTIPLEXER_OPEN
    :type: string
@@ -1695,7 +1700,7 @@ Marks
    .. versionadded:: 2.1
 
    .. versionchanged:: 2.2
-      Can be disabled by :attr:`LP_ENABLE_MUX`.
+      Can be disabled by :attr:`LP_ENABLE_MULTIPLEXER`.
 
 .. attribute:: LP_MARK_OS
    :type: array<string>
@@ -2151,7 +2156,7 @@ Valid preset color variables are:
    :attr:`LP_MARK_MULTIPLEXER_CLOSE` if the terminal is in a multiplexer.
 
    .. versionchanged:: 2.2
-      Can be disabled by :attr:`LP_ENABLE_MUX`.
+      Can be disabled by :attr:`LP_ENABLE_MULTIPLEXER`.
 
 .. attribute:: LP_COLOR_JOB_D
    :type: string

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -452,7 +452,7 @@ Features
 
    Detect if the connection has X11 support.
    
-   In the default them, display a green ``@`` if it does; a yellow one if not.
+   In the default theme, display a green ``@`` if it does; a yellow one if not.
 
    See also :attr:`LP_COLOR_X11_ON` and :attr:`LP_COLOR_X11_OFF`.
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -329,8 +329,8 @@ Environment
    .. versionadded:: 2.0
 
    .. versionchanged:: 2.2
-      Can be disabled by :attr:`LP_ENABLE_MUX`,
-      except if ``--internal`` is passed.
+      Can be disabled by :attr:`LP_ENABLE_MULTIPLEXER`,
+      except if ``--internal`` is passed (i.e. for internal use only).
 
 .. function:: _lp_shell_level() -> var:lp_shell_level
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -329,7 +329,8 @@ Environment
    .. versionadded:: 2.0
 
    .. versionchanged:: 2.2
-      Can be disabled by :attr:`LP_ENABLE_MUX`.
+      Can be disabled by :attr:`LP_ENABLE_MUX`,
+      except if ``--internal`` is passed.
 
 .. function:: _lp_shell_level() -> var:lp_shell_level
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -202,6 +202,9 @@ Environment
 
    .. versionadded:: 2.0
 
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_DISPLAY`.
+
 .. function:: _lp_connection() -> var:lp_connection
 
    Returns a string matching the connection context of the shell. Valid values:
@@ -325,6 +328,9 @@ Environment
 
    .. versionadded:: 2.0
 
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_MUX`.
+
 .. function:: _lp_shell_level() -> var:lp_shell_level
 
     Returns ``true`` if the shell is a nested shell inside another shell.
@@ -416,6 +422,9 @@ OS
    matching the chroot string if one is found.
 
    .. versionadded:: 2.0
+
+   .. versionchanged:: 2.2
+      Can be disabled by :attr:`LP_ENABLE_CHROOT`.
 
 .. function:: _lp_hostname() -> var:lp_hostname
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -419,6 +419,9 @@ __lp_source_config() {
     LP_DELIMITER_KUBECONTEXT_PREFIX=${LP_DELIMITER_KUBECONTEXT_PREFIX:-""}
     LP_ENV_VARS=( ${LP_ENV_VARS[@]+"${LP_ENV_VARS[@]}"} )
 
+    LP_ENABLE_DISPLAY=${LP_ENABLE_DISPLAY:-1}
+    LP_ENABLE_CHROOT=${LP_ENABLE_CHROOT:-1}
+    LP_ENABLE_MULTIPLEXER=${LP_ENABLE_MULTIPLEXER:-1}
     LP_ENABLE_PERM=${LP_ENABLE_PERM:-1}
     LP_ENABLE_SHORTEN_PATH=${LP_ENABLE_SHORTEN_PATH:-1}
     LP_ENABLE_PROXY=${LP_ENABLE_PROXY:-1}
@@ -1597,6 +1600,7 @@ _lp_path_format() {
 
 # If we are connected with a X11 support
 _lp_connected_display() {
+    (( LP_ENABLE_DISPLAY )) || return 2
     [[ -n "${DISPLAY-}" ]]
 }
 
@@ -1618,6 +1622,7 @@ _lp_connection() {
 }
 
 _lp_chroot() {
+    (( LP_ENABLE_CHROOT )) || return 2
     if [[ -r /etc/debian_chroot ]]; then
         IFS= read -r lp_chroot </etc/debian_chroot
         if [[ -n "$lp_chroot" ]]; then
@@ -1840,6 +1845,7 @@ _lp_error_meaning_color() {
 
 # shellcheck disable=SC2034
 _lp_multiplexer() {
+    (( LP_ENABLE_MULTIPLEXER )) || return 2
     if [[ -n ${TMUX-} ]]; then
         lp_multiplexer=tmux
         return 0

--- a/liquidprompt
+++ b/liquidprompt
@@ -1845,7 +1845,8 @@ _lp_error_meaning_color() {
 
 # shellcheck disable=SC2034
 _lp_multiplexer() {
-    (( LP_ENABLE_MULTIPLEXER )) || return 2
+    (( LP_ENABLE_SCREEN_TITLE || LP_ENABLE_TMUX_TITLE_PANES || LP_ENABLE_MULTIPLEXER )) || return 2
+
     if [[ -n ${TMUX-} ]]; then
         lp_multiplexer=tmux
         return 0
@@ -4455,7 +4456,7 @@ _lp_default_theme_activate() {
     LP_HOST="$lp_hostname_color"
 
     # If we are running in a terminal multiplexer, brackets are colored
-    if _lp_multiplexer; then
+    if (( LP_ENABLE_MULTIPLEXER && _lp_multiplexer  )); then
         LP_BRACKET_OPEN="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_MULTIPLEXER_OPEN}${NO_COL}"
         LP_BRACKET_CLOSE="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_MULTIPLEXER_CLOSE}${NO_COL}"
     else

--- a/liquidprompt
+++ b/liquidprompt
@@ -844,7 +844,7 @@ lp_activate() {
     [[ -n "${MC_SID-}" ]] && LP_ENABLE_SHORTEN_PATH=0
 
     # If we are running in a terminal multiplexer, special title escapes
-    if _lp_multiplexer; then
+    if _lp_multiplexer --internal; then
         (( LP_ENABLE_TITLE = LP_ENABLE_TITLE && LP_ENABLE_SCREEN_TITLE ))
         if (( LP_ENABLE_TMUX_TITLE_PANES )) && [[ $lp_multiplexer == tmux ]]; then
             LP_TITLE_OPEN=$'\E]2'
@@ -1843,9 +1843,15 @@ _lp_error_meaning_color() {
     lp_error_meaning_color="${LP_COLOR_ERR_MEANING}(${lp_error_meaning})${NO_COL}"
 }
 
+# Use --internal to avoid being disabled by LP_ENABLE_MULTIPLEXER.
+# Note: this still tests for LP_ENABLE_SCREEN_TITLE and LP_ENABLE_TMUX_TITLE_PANES.
 # shellcheck disable=SC2034
-_lp_multiplexer() {
-    (( LP_ENABLE_SCREEN_TITLE || LP_ENABLE_TMUX_TITLE_PANES || LP_ENABLE_MULTIPLEXER )) || return 2
+_lp_multiplexer() { # [--internal]
+    if [[ ${1-} == "--internal" ]]; then
+        (( LP_ENABLE_SCREEN_TITLE || LP_ENABLE_TMUX_TITLE_PANES )) || return 2
+    else
+        (( LP_ENABLE_MULTIPLEXER )) || return 2
+    fi
 
     if [[ -n ${TMUX-} ]]; then
         lp_multiplexer=tmux
@@ -4456,7 +4462,7 @@ _lp_default_theme_activate() {
     LP_HOST="$lp_hostname_color"
 
     # If we are running in a terminal multiplexer, brackets are colored
-    if (( LP_ENABLE_MULTIPLEXER && _lp_multiplexer  )); then
+    if _lp_multiplexer; then
         LP_BRACKET_OPEN="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_MULTIPLEXER_OPEN}${NO_COL}"
         LP_BRACKET_CLOSE="${LP_COLOR_IN_MULTIPLEXER}${LP_MARK_MULTIPLEXER_CLOSE}${NO_COL}"
     else


### PR DESCRIPTION
- `LP_ENABLE_DISPLAY`, use in `_lp_connected_display`,
- `LP_ENABLE_CHROOT`, use in `_lp_chroot`,
- `LP_ENABLE_MUX`, use in `_lp_multiplexer`

Refs: #796
