### PR TITLE
fix(_lp_fill): avoid costly strip_escape on filling sequence

### DIFF
--- a/docs/functions/util.rst
+++ b/docs/functions/util.rst
@@ -56,7 +56,7 @@ These functions are designed to be used by themes.
 
    See also :attr:`LP_ENABLE_HYPERLINKS` and :func:`_lp_create_link`.
 
-.. function:: _lp_fill(left, right, [fillstring], [splitends]) -> var:lp_fill
+.. function:: _lp_fill(left, right, [fillstring], [splitends, [fillprefix, [fillsuffix]]]) -> var:lp_fill
 
    Adds as much *fillstring* (e.g. spaces) between *left* and *right*,
    so as to make the resulting string the same width as the current terminal.
@@ -72,12 +72,12 @@ These functions are designed to be used by themes.
    some spaces will be inserted after the last occurrence of *fillstring*,
    so as to match the exact width of the terminal.
 
-   *fillstring* may contains escaped sequences (such as colors).
+   *fillstring* may NOT contains escaped sequences (such as colors).
 
-   .. note:: If *fillstring* have multiple characters and *splitends* is 1,
-             then **the last occurrence** of *fillstring*
-             is stripped of any escaped sequences
-             and only its printable characters are inserted.
+  .. note:: Any escaped sequence in *fillstring* will be removed automatically.
+
+   *fillprefix* and *fillsuffix* may be used to add escaped sequences at the
+   beginning and, respectively, the end of the filling sequence.
 
    If the available number of columns in the terminal is smaller than
    the width of *left* and *right* combined, then

--- a/docs/functions/util.rst
+++ b/docs/functions/util.rst
@@ -56,7 +56,7 @@ These functions are designed to be used by themes.
 
    See also :attr:`LP_ENABLE_HYPERLINKS` and :func:`_lp_create_link`.
 
-.. function:: _lp_fill(left, right, [fillstring], [splitends, [fillprefix, [fillsuffix]]]) -> var:lp_fill
+.. function:: _lp_fill(left, right, [fillstring, [splitends]]) -> var:lp_fill
 
    Adds as much *fillstring* (e.g. spaces) between *left* and *right*,
    so as to make the resulting string the same width as the current terminal.
@@ -72,12 +72,10 @@ These functions are designed to be used by themes.
    some spaces will be inserted after the last occurrence of *fillstring*,
    so as to match the exact width of the terminal.
 
-   *fillstring* may NOT contains escaped sequences (such as colors).
-
   .. note:: Any escaped sequence in *fillstring* will be removed automatically.
-
-   *fillprefix* and *fillsuffix* may be used to add escaped sequences at the
-   beginning and, respectively, the end of the filling sequence.
+            The end of *left* and the beginning of *right* may be used to add
+            escaped sequences at the beginning and, respectively, the end of
+            the filling sequence.
 
    If the available number of columns in the terminal is smaller than
    the width of *left* and *right* combined, then

--- a/liquidprompt
+++ b/liquidprompt
@@ -1254,51 +1254,60 @@ _lp_grep_fields() {
     done <"$file"
 }
 
-# Adds as much $3 character (e.g. spaces) between $1 and $2,
+# Adds as much $3 (fillchars) character(s) (e.g. spaces) between $1 (left) and $2 (right),
 # so as to make the resulting string the same width as the current terminal.
+# If $4 (splitends) is true, then will cut $3 (fillchars) so as to perfectly fill the available space.
+# If $5 (fillprefix) and $6 (fillsuffix) are passed, they will be used as perfix and suffix
+# of the filling sequence of characters.
+# WARNING: this function may be slow if you put escaped characters in $3 (fillchars)
+#          and the width of the gap to fill is large. Thus, any escaped character is
+#          removed from $3 (fillchars) at the beginning.
+#          To color the filling sequence, use $5 (fillprefix) and $6 (fillsuffix).
 _lp_fill() {
 
-    local left="$1" right="$2" fillchars="${3:-" "}" splitends="${4:-1}"
+    local left="$1" right="$2" fillchars="${3:-" "}" splitends="${4:-1}" fillprefix="${5:-""}" fillsuffix="${6:-""}"
+
+    # Remove any escaped character from fillchars,
+    # to avoid any costly __lp_strip_escape call on a potentially long
+    # sequence of characters.
+    __lp_strip_escapes "$fillchars"
+    fillchars="$ret"
 
     # Compute the gap between left and right.
     local ret
-    __lp_strip_escapes "$left"
+    __lp_strip_escapes "${left}${fillprefix}"
     local left_as_text="$ret"
-    __lp_strip_escapes "$right"
+    __lp_strip_escapes "${fillsuffix}${right}"
     local right_as_text="$ret"
+    # Width of the gap is width of the screen minus every printable characters.
     local gap_width=$((${COLUMNS:-80}-${#left_as_text}-${#right_as_text}))
     if [[ $gap_width -lt 0 ]] ; then
         lp_fill="${left}${right}"
         return 1
     fi
 
+    # Assemble a candidate filling sequence of characters.
     local filled=""
-    __lp_strip_escapes "$fillchars"
-    local fillchars_as_text="${ret}"
-    local fillchars_as_text_width=${#fillchars_as_text}
-    local nb_fillchars=$((gap_width/fillchars_as_text_width))
+    local fillchars_width=${#fillchars}
+    local nb_fillchars=$((gap_width/fillchars_width))
     local i
     for (( i=0; i < nb_fillchars; i++ )) ; do
         filled+="$fillchars"
     done
 
-    __lp_strip_escapes "$filled"
-    local actual_width=${#ret}
+    local actual_width=${#filled}
     # If there is still a gap (i.e. we have an unaligned multi-character fillchars).
     if [[ ${actual_width} -lt ${gap_width} ]] ; then
         # User asked for splitends.
         if [[ $splitends -ne 0 ]] ; then
-            # The last occurence is necessarily stripped from escaped sequences,
-            # or else we may have dangling sequences.
-            for (( i=_LP_FIRST_INDEX; i < $((${#fillchars_as_text}+_LP_FIRST_INDEX)); i++ )) ; do
+            for (( i=_LP_FIRST_INDEX; i < $((${#fillchars}+_LP_FIRST_INDEX)); i++ )) ; do
                 # Get one single character.
                 if (( _LP_SHELL_zsh )) ; then
-                    filled+="${fillchars_as_text[i,i]}"
+                    filled+="${fillchars[i,i]}"
                 else
-                    filled+="${fillchars_as_text:i:1}"
+                    filled+="${fillchars:i:1}"
                 fi
-                __lp_strip_escapes "$filled"
-                actual_width=${#ret}
+                actual_width=${#filled}
                 if [[ ${actual_width} -ge ${gap_width} ]] ; then
                     # Stop at this char if we're full.
                     break
@@ -1313,7 +1322,7 @@ _lp_fill() {
     fi
 
     # shellcheck disable=SC2034
-    lp_fill="${left}${filled}${right}"
+    lp_fill="${left}${fillprefix}${filled}${fillsuffix}${right}"
 }
 
 _lp_version_string() { # [major, [minor, [patch, [string, [number]]]]]

--- a/liquidprompt
+++ b/liquidprompt
@@ -1257,11 +1257,13 @@ _lp_grep_fields() {
 # Adds as much $3 (fillchars) character(s) (e.g. spaces) between $1 (left) and $2 (right),
 # so as to make the resulting string the same width as the current terminal.
 # If $4 (splitends) is true, then will cut $3 (fillchars) so as to perfectly fill the available space.
-# WARNING: this function may be slow if you put escaped characters in $3 (fillchars)
-#          and the width of the gap to fill is large. Thus, any escaped character is
-#          removed from $3 (fillchars) at the beginning.
-#          To color the filling sequence, you can add formating at the end of $1 (left)
-#          and/or at the beginning of $2 (right).
+#
+# This function would have been slow if you put escaped characters in $3 (fillchars)
+# and the width of the gap to fill is large. Thus, any escaped character is
+# removed from $3 (fillchars) at the beginning.
+#
+# To color the filling sequence, you can add formating at the end of $1 (left)
+# and/or at the beginning of $2 (right).
 _lp_fill() {
 
     local left="$1" right="$2" fillchars="${3:-" "}" splitends="${4:-1}"
@@ -1278,7 +1280,7 @@ _lp_fill() {
     local left_as_text="$ret"
     __lp_strip_escapes "${right}"
     local right_as_text="$ret"
-    # Width of the gap is width of the screen minus every printable characters.
+    # Width of the gap is width of the screen minus every printable character.
     local gap_width=$((${COLUMNS:-80}-${#left_as_text}-${#right_as_text}))
     if [[ $gap_width -lt 0 ]] ; then
         lp_fill="${left}${right}"

--- a/liquidprompt
+++ b/liquidprompt
@@ -1257,15 +1257,14 @@ _lp_grep_fields() {
 # Adds as much $3 (fillchars) character(s) (e.g. spaces) between $1 (left) and $2 (right),
 # so as to make the resulting string the same width as the current terminal.
 # If $4 (splitends) is true, then will cut $3 (fillchars) so as to perfectly fill the available space.
-# If $5 (fillprefix) and $6 (fillsuffix) are passed, they will be used as perfix and suffix
-# of the filling sequence of characters.
 # WARNING: this function may be slow if you put escaped characters in $3 (fillchars)
 #          and the width of the gap to fill is large. Thus, any escaped character is
 #          removed from $3 (fillchars) at the beginning.
-#          To color the filling sequence, use $5 (fillprefix) and $6 (fillsuffix).
+#          To color the filling sequence, you can add formating at the end of $1 (left)
+#          and/or at the beginning of $2 (right).
 _lp_fill() {
 
-    local left="$1" right="$2" fillchars="${3:-" "}" splitends="${4:-1}" fillprefix="${5:-""}" fillsuffix="${6:-""}"
+    local left="$1" right="$2" fillchars="${3:-" "}" splitends="${4:-1}"
 
     # Remove any escaped character from fillchars,
     # to avoid any costly __lp_strip_escape call on a potentially long
@@ -1275,9 +1274,9 @@ _lp_fill() {
 
     # Compute the gap between left and right.
     local ret
-    __lp_strip_escapes "${left}${fillprefix}"
+    __lp_strip_escapes "${left}"
     local left_as_text="$ret"
-    __lp_strip_escapes "${fillsuffix}${right}"
+    __lp_strip_escapes "${right}"
     local right_as_text="$ret"
     # Width of the gap is width of the screen minus every printable characters.
     local gap_width=$((${COLUMNS:-80}-${#left_as_text}-${#right_as_text}))
@@ -1322,7 +1321,7 @@ _lp_fill() {
     fi
 
     # shellcheck disable=SC2034
-    lp_fill="${left}${fillprefix}${filled}${fillsuffix}${right}"
+    lp_fill="${left}${filled}${right}"
 }
 
 _lp_version_string() { # [major, [minor, [patch, [string, [number]]]]]

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -804,20 +804,20 @@ function test_lp_fill {
     _lp_fill "L" "R" "123" 1
     assertEquals "multi-fill 6 split" "L1231R" "$lp_fill"
 
-    _lp_fill "L" "R" "123" 0 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    _lp_fill "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "R" "123" 0
     assertEquals "multi-fill 6 with escape and no split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123 R" "$lp_fill"
 
-    _lp_fill "L" "R" "123" 0 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    _lp_fill "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}R" "123" 0
     assertEquals "multi-fill 6 with double escapes and no split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123 ${_LP_OPEN_ESC}${_LP_CLOSE_ESC}R" "$lp_fill"
 
     _lp_fill "L" "R" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 1
     assertEquals "multi-fill 6 with wrong escape and split" "L1231R" "$lp_fill"
 
-    _lp_fill "L" "R" "123" 1 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    _lp_fill "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "R" "123" 1
     assertEquals "multi-fill 6 with escape and split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231R" "$lp_fill"
 
-    _lp_fill "L" "R" "123" 1 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
-    assertEquals "multi-fill 6 with double escapes and split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231${_LP_OPEN_ESC}${_LP_CLOSE_ESC}R" "$lp_fill"
+    _lp_fill "L" "R" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" 1
+    assertEquals "multi-fill 6 with double escapes and split" "L1231R" "$lp_fill"
 
     COLUMNS=11
     _lp_fill "Left" "Right" "="
@@ -835,11 +835,11 @@ function test_lp_fill {
     _lp_fill "Le" "Ri" "123" 1
     assertEquals "multi-fill 11 with split" "Le1231231Ri" "$lp_fill"
 
-    _lp_fill "Le" "Ri" "123" 0 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    _lp_fill "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "Ri" "123" 0
     assertEquals "multi-fill 11 with escape and no split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123123 Ri" "$lp_fill"
 
-    _lp_fill "Le" "Ri" "123" 1 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
-    assertEquals "multi-fill 11 with double escape and split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231231${_LP_OPEN_ESC}${_LP_CLOSE_ESC}Ri" "$lp_fill"
+    _lp_fill "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "Ri" "123${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" 1
+    assertEquals "multi-fill 11 with double escape and split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231231Ri" "$lp_fill"
 
     # The following tests require a UTF-8 locale to be set.
     # The Windows runners have issues with these Unicode characters.

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -804,11 +804,20 @@ function test_lp_fill {
     _lp_fill "L" "R" "123" 1
     assertEquals "multi-fill 6 split" "L1231R" "$lp_fill"
 
-    _lp_fill "L" "R" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 0
+    _lp_fill "L" "R" "123" 0 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
     assertEquals "multi-fill 6 with escape and no split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123 R" "$lp_fill"
 
+    _lp_fill "L" "R" "123" 0 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    assertEquals "multi-fill 6 with double escapes and no split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123 ${_LP_OPEN_ESC}${_LP_CLOSE_ESC}R" "$lp_fill"
+
     _lp_fill "L" "R" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 1
+    assertEquals "multi-fill 6 with wrong escape and split" "L1231R" "$lp_fill"
+
+    _lp_fill "L" "R" "123" 1 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
     assertEquals "multi-fill 6 with escape and split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231R" "$lp_fill"
+
+    _lp_fill "L" "R" "123" 1 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    assertEquals "multi-fill 6 with double escapes and split" "L${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231${_LP_OPEN_ESC}${_LP_CLOSE_ESC}R" "$lp_fill"
 
     COLUMNS=11
     _lp_fill "Left" "Right" "="
@@ -826,11 +835,11 @@ function test_lp_fill {
     _lp_fill "Le" "Ri" "123" 1
     assertEquals "multi-fill 11 with split" "Le1231231Ri" "$lp_fill"
 
-    _lp_fill "Le" "Ri" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 0
-    assertEquals "multi-fill 11 with escape and no split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123 Ri" "$lp_fill"
+    _lp_fill "Le" "Ri" "123" 0 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    assertEquals "multi-fill 11 with escape and no split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123123 Ri" "$lp_fill"
 
-    _lp_fill "Le" "Ri" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123" 1
-    assertEquals "multi-fill 11 with escape and split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}123${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231Ri" "$lp_fill"
+    _lp_fill "Le" "Ri" "123" 1 "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}" "${_LP_OPEN_ESC}${_LP_CLOSE_ESC}"
+    assertEquals "multi-fill 11 with double escape and split" "Le${_LP_OPEN_ESC}${_LP_CLOSE_ESC}1231231${_LP_OPEN_ESC}${_LP_CLOSE_ESC}Ri" "$lp_fill"
 
     # The following tests require a UTF-8 locale to be set.
     # The Windows runners have issues with these Unicode characters.

--- a/themes/unfold/unfold.theme
+++ b/themes/unfold/unfold.theme
@@ -23,13 +23,13 @@ _lp_unfold_theme_prompt() {
     left+="${LP_VCS}"
 
     # Add the list of development environments/config/etc.
-    local right+="${LP_DEV_ENV}${LP_JOBS}${LP_BATT}${LP_LOAD}${LP_TEMP}${LP_RAM}${LP_DISK}${LP_WIFI}${LP_TIME}"
+    local right+="${LP_DEV_ENV} ${LP_JOBS}${LP_BATT}${LP_LOAD}${LP_TEMP}${LP_RAM}${LP_DISK}${LP_WIFI}${LP_TIME}"
 
     # add return code and prompt mark
     local main+="${LP_RUNTIME}${LP_ERR}${LP_MARK_PREFIX}${LP_COLOR_MARK}${LP_MARK}${LP_PS1_POSTFIX}"
 
     local n=$'\n'
-    _lp_fill "$left" "$right"
+    _lp_fill "$left" "$right" " " 0 "" ""
     PS1="${lp_fill}${n}${main}"
 
     # Get the core sections without prompt escapes and make them into a title.

--- a/tools/theme-preview.sh
+++ b/tools/theme-preview.sh
@@ -2,8 +2,6 @@
 #shellcheck disable=SC2317
 set -u
 
-COLUMNS=160
-
 . ./liquidprompt --no-activate
 
 # If a theme was given, use the theme and source all other arguments.
@@ -170,7 +168,6 @@ printf 'Medium prompt:\n\n%s\n\n' "$PS1"
 _long_config() {
   LP_ENABLE_SHORTEN_PATH=1
   LP_PATH_LENGTH=29
-  COLUMNS=100
   LP_PATH_KEEP=1
   LP_PATH_VCS_ROOT=1
   LP_ENABLE_TIME=1


### PR DESCRIPTION
The previous behavior was to allow escaped sequences in the *fillchars* argument of _lp_fill. This could lead to a very slow call to __lp_strip_escapes if the gap was large.

The new behavior is to remove escaped sequences from fillchars, but allow them in the new arguments *fillprefix* and *fillsuffix*.

This actually simplifies the _lp_fill function a bit.

This patch also removes fixed COLUMNS in theme-preview.sh and fix a spacing problem in the unfold theme.

Ref: [this thread on liquidprompt-powerline](https://github.com/liquidprompt/liquidprompt-powerline/pull/2#pullrequestreview-1711142969)