### PR TITLE
Candidate for minor spelling correction in two places

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ code change:
     - [ ] subshells are avoided as much as possible
 - tests and checks have been added, ran, and their warnings fixed:
     - [ ] unit tests have been updated (see `tests/test_*.sh` files)
-    - [ ] ran `test.sh`
+    - [ ] ran `tests.sh`
     - [ ] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
 - documentation have been updated accordingly:
     - [ ] functions and attributes are documented in alphabetical order

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -19,7 +19,7 @@
     - [ ] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
 - tests and checks have been added, ran, and their warnings fixed:
     - [ ] unit tests have been updated (see `tests/test_*.sh` files)
-    - [ ] ran `test.sh`
+    - [ ] ran `tests.sh`
     - [ ] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
 - documentation have been updated accordingly:
     - [ ] functions and attributes are documented in alphabetical order


### PR DESCRIPTION
Hi,

Corrected what I believe to be a spelling error, since I could not locate the referenced file, found one with the corrected name instead.

The technical checklist does not seem appropriate in this case.

I have corrected in both the documentation and the pull request template.

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [ ] correct use of `IFS`
    - [ ] careful quoting
    - [ ] cautious array access
    - [ ] portable array indexing with `_LP_FIRST_INDEX`
    - [ ] printing a "%" character is done with `_LP_PERCENT`
    - [ ] functions/variable naming conventions
    - [ ] functions have local variables
    - [ ] data functions have optimization guards (early exits)
    - [ ] subshells are avoided as much as possible
    - [ ] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, ran, and their warnings fixed:
    - [ ] unit tests have been updated (see `tests/test_*.sh` files)
    - [ ] ran `test.sh`
    - [ ] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - [ ] functions and attributes are documented in alphabetical order
    - [ ] new sections are documented in the default theme
    - [ ] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [ ] functions signatures have arguments, returned code, and set value(s)
    - [ ] attributes have types and defaults
    - [ ] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))


