### PR TITLE
Avoid running __lp_set_prompt multiple times

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -4913,8 +4913,10 @@ prompt_on() {
 
             if (( ${BASH_VERSINFO[0]:-0} > 5 || ( ${BASH_VERSINFO[0]:-0} == 5 && ${BASH_VERSINFO[1]:-0} >= 1 ) )); then
                 # PROMPT_COMMAND is an array since bash 5.1
-                PROMPT_COMMAND+=( "$set_prompt_command" )
-
+                if ! ( __lp_array_contains __lp_set_prompt ${PROMPT_COMMAND[@]+"${PROMPT_COMMAND[@]}"} \
+                  || __lp_array_contains "time __lp_set_prompt" ${PROMPT_COMMAND[@]+"${PROMPT_COMMAND[@]}"} ); then
+                   PROMPT_COMMAND+=( "$set_prompt_command" )
+                fi
             else
                 if [[ -z ${LP_OLD_PROMPT_COMMAND+x} ]]; then
                     LP_OLD_PROMPT_COMMAND="${PROMPT_COMMAND-}"


### PR DESCRIPTION
Unlike lp_activate lp_theme hasn't cleand PROMPT_COMMAND. Thus, __lp_set_prompt was dded each time a theme was switched. In case of a single theme switch (e.g. from the default to dotmatrix) the performance hit due to running __lp_set_prompt twice wasn't noticable. However, the second time the function was called, it didn't show the last command runtime properly even if it was longer than LP_RUNTIME_THRESHOLD.

Fixes: 3553a65 ("Add support for Bash 5.1+ PROMPT_COMMAND array")


<!-- Provide a description here -->

<!-- Related issue: #XXX -->


# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - the code has been copied from 3553a65
- tests and checks have been added, ran, and their warnings fixed:
    - [ ] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - no — this is a bugfix
