### PR TITLE
Avoid showing the 130 error code after hitting ^C

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1174,6 +1174,18 @@ Features
 
    .. versionadded:: 2.1
 
+.. attribute:: LP_HIDE_EMPTY_ERROR
+   :type: bool
+   :value: 1
+
+   Hide the error code returned by a command if the new prompt is displayed
+   after the user hits Ctrl-C or submits an empty command (i.e. empty string
+   or a comment).
+
+   See also: :attr:`LP_ENABLE_ERROR`.
+
+   .. versionadded:: 2.2
+
 .. attribute:: LP_HOSTNAME_ALWAYS
    :type: int
    :value: 0

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,5 +1,6 @@
 Archlinux
 CMake
+Ctrl
 Cygwin
 DragonFly
 FreeBSD

--- a/liquidprompt
+++ b/liquidprompt
@@ -486,6 +486,7 @@ __lp_source_config() {
     LP_ENABLE_OS_VERSION=${LP_ENABLE_OS_VERSION:-1}
     LP_ENABLE_HYPERLINKS=${LP_ENABLE_HYPERLINKS:-0}
     LP_ENABLE_PATH=${LP_ENABLE_PATH:-1}
+    LP_HIDE_EMPTY_ERROR=${LP_HIDE_EMPTY_ERROR:-1}
 
     LP_MARK_DEFAULT="${LP_MARK_DEFAULT:-$_LP_MARK_SYMBOL}"
     LP_MARK_BATTERY="${LP_MARK_BATTERY:-"⌁"}"
@@ -834,6 +835,7 @@ lp_activate() {
         LP_ENABLE_RUNTIME \
         || LP_ENABLE_RUNTIME_BELL \
         || LP_ENABLE_TITLE_COMMAND \
+        || LP_HIDE_EMPTY_ERROR \
     ))
 
     # LP_ENABLE_RUBY_VENV depends either from rvm or rbenv. Thus we cannot
@@ -4810,6 +4812,11 @@ __lp_set_prompt() {
     # As this get the last returned code, it should be called first
     local -i lp_error="$?"
 
+    if (( LP_HIDE_EMPTY_ERROR )); then
+        (( ! ${_LP_REAL_COMMAND:-1} )) && lp_error=0
+        _LP_REAL_COMMAND=0
+    fi
+
     if (( LP_ENABLE_RUNTIME || LP_ENABLE_RUNTIME_BELL )); then
         __lp_runtime_after
     fi
@@ -4857,6 +4864,9 @@ __lp_preexec() {
     fi
     if (( LP_ENABLE_TITLE_COMMAND )); then
         __lp_print_title_command
+    fi
+    if (( LP_HIDE_EMPTY_ERROR )); then
+        _LP_REAL_COMMAND=1
     fi
 }
 


### PR DESCRIPTION
When a user hits ^C on command line to cancel entering a lengthy command, $! in __lp_set_prompt is set to 130 (128 + SIGINT). Displaying this error on the input line (especially in warning colours) makes little sense. Therefore, liquidprompt should check if the command submitted is a real command or is it part of PROMPT_COMMAND in which case the error does not come from a user's command and should not be presented.


<!-- Provide a description here -->

<!-- Related issue: #XXX -->


# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [ ] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [ ] portable array indexing with `_LP_FIRST_INDEX`
    - [ ] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [ ] data functions have optimization guards (early exits)
    - [ ] subshells are avoided as much as possible
    - [ ] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, ran, and their warnings fixed:
    - [ ] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - [ ] functions and attributes are documented in alphabetical order
    - [ ] new sections are documented in the default theme
    - [ ] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [ ] functions signatures have arguments, returned code, and set value(s)
    - [ ] attributes have types and defaults
    - [ ] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))


