### PR TITLE
Remove superfluous / duplicate squared brakets from AWS profile definition

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -2151,7 +2151,6 @@ _lp_software_collections_color() {
     lp_software_collections_color="${LP_COLOR_VIRTUALENV}${lp_software_collections}${NO_COL}"
 }
 
-
 _lp_kubernetes_context() {
     (( LP_ENABLE_KUBECONTEXT )) || return 2
 
@@ -2194,6 +2193,27 @@ _lp_kubernetes_context_color() {
     _lp_kubernetes_context || return "$?"
 
     lp_kubernetes_context_color="${LP_MARK_KUBECONTEXT}${LP_COLOR_KUBECONTEXT}${lp_kubernetes_context}${lp_kubernetes_namespace+:}${lp_kubernetes_namespace-}${NO_COL}"
+}
+
+_lp_aws_profile() {
+    (( LP_ENABLE_AWS_PROFILE )) || return 2
+
+    local ret
+
+    local aws_profile="${AWS_PROFILE-${AWS_DEFAULT_PROFILE-${AWS_VAULT-}}}"
+    if [[ -n $aws_profile ]]; then
+        __lp_escape "${aws_profile}"
+        lp_aws_profile=$ret
+    else
+        return 1
+    fi
+}
+
+_lp_aws_profile_color() {
+    unset lp_aws_profile_color
+    _lp_aws_profile || return "$?"
+
+    lp_aws_profile_color="[${LP_COLOR_AWS_PROFILE}${lp_aws_profile}${NO_COL}]"
 }
 
 
@@ -2490,27 +2510,6 @@ _lp_dirstack_color() {
     _lp_dirstack || return "$?"
 
     lp_dirstack_color="${LP_COLOR_DIRSTACK}${LP_MARK_DIRSTACK}${lp_dirstack}${NO_COL}"
-}
-
-_lp_aws_profile() {
-    (( LP_ENABLE_AWS_PROFILE )) || return 2
-
-    local ret
-
-    local aws_profile="${AWS_PROFILE-${AWS_DEFAULT_PROFILE-${AWS_VAULT-}}}"
-    if [[ -n $aws_profile ]]; then
-        __lp_escape "${aws_profile}"
-        lp_aws_profile=$ret
-    else
-        return 1
-    fi
-}
-
-_lp_aws_profile_color() {
-    unset lp_aws_profile_color
-    _lp_aws_profile || return "$?"
-
-    lp_aws_profile_color="[${LP_COLOR_AWS_PROFILE}${lp_aws_profile}${NO_COL}]"
 }
 
 _lp_shell_level() {

--- a/liquidprompt
+++ b/liquidprompt
@@ -2213,7 +2213,7 @@ _lp_aws_profile_color() {
     unset lp_aws_profile_color
     _lp_aws_profile || return "$?"
 
-    lp_aws_profile_color="[${LP_COLOR_AWS_PROFILE}${lp_aws_profile}${NO_COL}]"
+    lp_aws_profile_color="${LP_COLOR_AWS_PROFILE}${lp_aws_profile}${NO_COL}"
 }
 
 


### PR DESCRIPTION
The upcoming 2.2.0 release introduces new mechanism to either join or display individual dev env variables. At one point one removed the various hardcoded enclosing squared brackets from the various colored definition of each dev env variable to allow to join them, but miss the AWS profile one.

This may come from the fact the AWS functions were a bit misplaced in the file. Thus the first commit of this MR move back the code (without modifying it) up in the file, alongside other dev env definition. Then the second commit remove the duplicate brackets.

# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [X] correct use of `IFS`
    - [X] careful quoting
    - [X] cautious array access
    - [X] portable array indexing with `_LP_FIRST_INDEX`
    - [X] printing a "%" character is done with `_LP_PERCENT`
    - [X] functions/variable naming conventions
    - [X] functions have local variables
    - [X] data functions have optimization guards (early exits)
    - [X] subshells are avoided as much as possible
    - [X] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, ran, and their warnings fixed:
    - [X] unit tests have been updated (see `tests/test_*.sh` files)
    - [X] ran `tests.sh`
    - [X] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - [X] functions and attributes are documented in alphabetical order
    - [X] new sections are documented in the default theme
    - [X] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [X] functions signatures have arguments, returned code, and set value(s)
    - [X] attributes have types and defaults
    - [X] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))

