### PR TITLE
Deprecate Powerline themes

### DIFF
--- a/docs/theme.rst
+++ b/docs/theme.rst
@@ -53,22 +53,21 @@ Liquid Prompt can switch between themes on the fly. The shell does not need to
 be reloaded, and no files need to be sourced after the initial source.
 
 To load (but not activate) a theme, simply source the theme file. For example,
-to load the included Powerline theme, source the theme file::
+to load the included Alternate VCS Details theme, source the theme file::
 
-   $ source themes/powerline/powerline.theme
+   $ source themes/alternate_vcs/alternate_vcs.theme
 
-Now both the default theme and Powerline are loaded. To show what themes are
+Now both the default theme and Alternate VCS are loaded. To show what themes are
 loaded and available, run :func:`lp_theme`::
 
    $ lp_theme --list
    default
-   powerline_full
-   powerline
+   alternate_vcs
 
 To switch to a different theme, call :func:`lp_theme` with the name of the theme
 as the argument::
 
-   $ lp_theme powerline
+   $ lp_theme alternate_vcs
 
 The prompt will immediately take on the new theme.
 

--- a/docs/theme/included/alternate_vcs.rst
+++ b/docs/theme/included/alternate_vcs.rst
@@ -2,7 +2,7 @@
 Alternate VCS Details Theme
 ***************************
 
-The included ``themes/powerline/alternate_vcs.theme`` file includes a theme
+The included ``themes/alternate_vcs/alternate_vcs.theme`` file includes a theme
 extending the default theme but replacing the VCS details display.
 
 .. contents::

--- a/docs/theme/included/powerline.rst
+++ b/docs/theme/included/powerline.rst
@@ -2,6 +2,11 @@
 Powerline Theme
 ***************
 
+.. deprecated:: 2.2
+   Use the spun off project `Liquid Prompt Powerline`_ instead.
+
+.. _`Liquid Prompt Powerline`: https://github.com/liquidprompt/liquidprompt-powerline
+
 The included ``themes/powerline/powerline.theme`` file includes two themes:
 
 .. contents::
@@ -18,6 +23,9 @@ Powerline does, but faster.
 That said, this is a fully usable theme.
 
 .. versionadded:: 2.0
+
+.. deprecated:: 2.2
+   Use the spun off project `Liquid Prompt Powerline`_ instead.
 
 .. _`Powerline prompt`: https://github.com/powerline/powerline
 .. _`default segments`: https://github.com/powerline/powerline/blob/2.8/powerline/config_files/themes/shell/default.json
@@ -262,6 +270,9 @@ sources that Liquid Prompt provides. The ordering is the same as the default
 theme.
 
 .. versionadded:: 2.0
+
+.. deprecated:: 2.2
+   Use the spun off project `Liquid Prompt Powerline`_ instead.
 
 Preview
 =======


### PR DESCRIPTION
Now that they have been split to a separate repo, mark the built in themes as deprecated in the docs.

Fix a few places elsewhere in the docs where the Powerline theme was mentioned as the best example of a theme.