### PR TITLE
Disk Space fixes

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1320,7 +1320,8 @@ Thresholds
    :value: 100000
 
    Display something if the available space on the hard drive hosting the
-   current directory goes below this absolute threshold *in kilobytes*.
+   current directory goes below this absolute threshold *in kilobytes*. If the
+   filesystem is smaller than :attr:`LP_DISK_THRESHOLD`, this check is skipped.
 
    The threshold for disk can also be set with :attr:`LP_DISK_THRESHOLD_PERC`,
    the first one to be reached triggering the display.

--- a/liquidprompt
+++ b/liquidprompt
@@ -4287,7 +4287,8 @@ _lp_disk() {
     [[ -z ${lp_disk} || -z ${lp_disk_perc} ]] && return 1
 
     # Comparison in KiB.
-    if (( lp_disk <= LP_DISK_THRESHOLD || lp_disk_perc <= LP_DISK_THRESHOLD_PERC )); then
+    # Ignore absolute threshold if whole FS is smaller than it; otherwise we would always show disk mark
+    if (( ( total >= LP_DISK_THRESHOLD && lp_disk <= LP_DISK_THRESHOLD ) || lp_disk_perc <= LP_DISK_THRESHOLD_PERC )); then
         # df outputs in KiB, but it's more robust to implement lp_human in bytes,
         # so we need to convert b in KiB here.
         local lp_bytes lp_bytes_units

--- a/liquidprompt
+++ b/liquidprompt
@@ -4261,20 +4261,25 @@ _lp_disk() {
     # Example output:
     # Filesystem     1024-blocks      Used Available Capacity Mounted on
     # /dev/nvme0n1p2   479608528 425188220  30011332      94% /
+    # For pseudo filesystems (like procfs or sysfs) output can be:
+    # Filesystem     1024-blocks  Used Available Capacity Mounted on
+    # sysfs                    0     0         0        - /sys
 
-    # Placeholder and capacity.
-    local _ capa
+    # Placeholder, total and capacity.
+    local _ total capa
     # Compute location of the targeted column on the safe line.
     local short="${df#*1024-blocks}"
     # Second line.
     local second="${df#*$'\n'}"
     # Consider only targeted columns.
     # This may be extended to get other information if needed:
-    #       +- total
-    #       | +- used        +- mount point (may have spaces)
-    #       | |              |
-    #       v v              v
-    read -r _ _ lp_disk capa _ <<<"${second:${#df}-${#short}-11}"
+    #             +- used        +- mount point (may have spaces)
+    #             |              |
+    #             v              v
+    read -r total _ lp_disk capa _ <<<"${second:${#df}-${#short}-11}"
+
+    # Skip small (under 1MiB) filesystems (probably pseudofs or something weird)
+    (( ${total:-0} < 1024 )) && return 1
 
     # Without percent character.
     lp_disk_perc=$(( 100 - ${capa:0:${#capa}-1} ))

--- a/tests/test_disk.sh
+++ b/tests/test_disk.sh
@@ -38,6 +38,14 @@ C:/Program Files/cygwin64  1999659004 450860152 1548798852      23% C:/Program F
 values+=(1548798852)
 values_human+=("1.44 TiB")
 
+names+=("FreeBSD small FS, but over 1MB")
+outputs+=(
+'Filesystem      1024-blocks Used Avail Capacity  Mounted on
+/dev/gpt/efiesp       32764  646 32117     2%    /boot/efi'
+)
+values+=(32117)
+values_human+=("31.36 MiB")
+
 names+=("FreeBSD special FS")
 outputs+=(
 'Filesystem 1024-blocks Used Avail Capacity  Mounted on
@@ -72,9 +80,14 @@ function test_disk {
             assertFalse "Parsing of \"${names[i]}\" skipped" "$?"
         fi
 
-        LP_DISK_THRESHOLD_PERC=0
-        LP_DISK_THRESHOLD=0
-        assertFalse "Above threshold" _lp_disk
+        # Note: percent threshold should be below available space in the least
+        #       available space case ("Simple Linux"), but absolute threshold
+        #       should be slightly larger than "FreeBSD small FS" test case,
+        #       so we can fully test the "total >= LP_DISK_THRESHOLD" condition.
+        LP_DISK_THRESHOLD_PERC=5
+        LP_DISK_THRESHOLD=100000
+        _lp_disk
+        assertFalse "Above threshold for \"${names[i]}\"" "$?"
     done
 }
 

--- a/tests/test_disk.sh
+++ b/tests/test_disk.sh
@@ -38,6 +38,22 @@ C:/Program Files/cygwin64  1999659004 450860152 1548798852      23% C:/Program F
 values+=(1548798852)
 values_human+=("1.44 TiB")
 
+names+=("FreeBSD special FS")
+outputs+=(
+'Filesystem 1024-blocks Used Avail Capacity  Mounted on
+devfs                1    0     1     0%    /dev'
+)
+values+=("")
+values_human+=("")
+
+names+=("Linux special FS")
+outputs+=(
+'Filesystem     1024-blocks  Used Available Capacity Mounted on
+sysfs                    0     0         0        - /sys'
+)
+values+=("")
+values_human+=("")
+
 function test_disk {
     for (( i=0; i < ${#outputs[@]}; i++ )); do
         df() {
@@ -46,10 +62,15 @@ function test_disk {
 
         LP_DISK_THRESHOLD_PERC=99
         LP_DISK_THRESHOLD=10000000000
-        _lp_disk
-        assertEquals "Parsing of \"${names[i]}\" without error" "0" "$?"
-        assertEquals "Correct parsing of \"${names[i]}\" in KiB" "${values[i]}" "$lp_disk"
-        assertEquals "Correct parsing of \"${names[i]}\" for human" "${values_human[i]}" "$lp_disk_human $lp_disk_human_units"
+        if [ -n "${values[i]}" ]; then
+            _lp_disk
+            assertEquals "Parsing of \"${names[i]}\" without error" "0" "$?"
+            assertEquals "Correct parsing of \"${names[i]}\" in KiB" "${values[i]}" "$lp_disk"
+            assertEquals "Correct parsing of \"${names[i]}\" for human" "${values_human[i]}" "$lp_disk_human $lp_disk_human_units"
+        else
+            _lp_disk
+            assertFalse "Parsing of \"${names[i]}\" skipped" "$?"
+        fi
 
         LP_DISK_THRESHOLD_PERC=0
         LP_DISK_THRESHOLD=0


### PR DESCRIPTION
Hi!
I ❤️ the disk space feature, simple thing but very useful. This PR tries to fix two small issues I've encountered with it. Both commits include unit tests updates to cover new cases.

#### 1. LP with disk space enabled breaks on pseudo filesystems like procfs and sysfs:

```
21:36:50 [mg@sirius:~] $ df -k -P /sys
Filesystem     1024-blocks  Used Available Capacity Mounted on
sysfs                    0     0         0        - /sys
21:36:55 [mg@sirius:~] $ cd /sys
bash: 100 -  : syntax error: operand expected (error token is "-  ")
21:36:55 [mg@sirius:~] $ pwd
/sys
# cd command worked; so expecting following prompt instead:
# 21:36:58 [mg@sirius:/sys] $
```
Note how Linux df reports `-` instead of `<value>%`, which breaks `lp_disk_perc=$(( 100 - ${capa:0:${#capa}-1} ))` calculation, cause the whole ${capa...} expands to empty value and triggers the "syntax error" as seen above.

At first, I've added explicit check for capa == "-", but then I've started my FreeBSD VM and saw it reports pseudo filesystems like normal ones (no dashes), but very small (total=1kiB devfs, or 8kiB procfs). Because of that, I've decided to check "total" column and reject all suspiciously small (<1 MiB) filesystems.


#### 2. I'm using following settings and I often work with relatively small (1-4GiB) filesystem images, which when mounted leads to not-so-useful mark in the prompt:

```
LP_ALWAYS_DISPLAY_VALUES=1
LP_DISPLAY_VALUES_AS_PERCENTS=1
LP_DISK_THRESHOLD=5000000   # ~5GB
LP_DISK_THRESHOLD_PERC=5

21:51:41 [mg@sirius:~] $ cd /mnt/image
21:51:45 🖴 88% [mg@sirius:/mnt/image] $ df -k -P .
Filesystem     1024-blocks   Used Available Capacity Mounted on
/dev/loop0         1977080 204824   1653472      12% /mnt/image
```
Note only 12% is used, but LP shows 88% free space mark which is way over the 5% I've set. This happens because the whole FS is smaller than my LP_DISK_THRESHOLD so it always matches the `lp_disk <= LP_DISK_THRESHOLD` condition.

To counter that, I've extended the condition to check LP_DISK_THRESHOLD only when FS is larger than it. However, I'm not sure whether this is the right thing to do. While it fixes my problem, maybe somebody with LP_DISPLAY_VALUES_AS_PERCENTS=0 would still like to have the value printed...