### PR TITLE
Fix `systemd-nspawn` container detection

### DIFF
--- a/liquidprompt
+++ b/liquidprompt
@@ -4649,14 +4649,14 @@ _lp_container() {
             lp_container="Docker"
         elif [[ "$cgroup" == *"lxc"* ]]; then
             lp_container="LXC"
+        elif [[ -r /run/host/container-manager ]]; then
+            local ret
+            IFS='' read -r ret < /run/host/container-manager
+            __lp_escape "${ret#systemd-}"
+            lp_container="$ret"
         else
             return 1
         fi
-    elif [[ -r /run/host/container-manager ]]; then
-        local ret
-        IFS='' read -r ret < /run/host/container-manager
-        __lp_escape "${ret#systemd-}"
-        lp_container="$ret"
     else
         return 1
     fi


### PR DESCRIPTION
When in `systemd-nspawn` container, `/proc/self/cgroup` is always present: https://systemd.io/CONTAINER_INTERFACE/ . So `elif [[ -r /run/host/container-manager ]]` branch cannot ever be reached.

The PR moves this `elif` inside the branch that processes `/proc/self/cgroup`.