### PR TITLE
Add support for Zsh named directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- **path**: Properly display [Zsh named directories](https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-hash-1) in path.
 
 ## [2.2.1] - 2024-07-01
 ### Added

--- a/docs/functions/internal.rst
+++ b/docs/functions/internal.rst
@@ -172,6 +172,10 @@ Path
       Return method changed from stdout.
       Optional parameter *path* added.
 
+   .. versionchanged:: 2.3
+      Added support for `Zsh named directories <https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-hash-1>`_.
+      Use `print -D` internal function on Zsh.
+
 Prompt
 ------
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -1314,10 +1314,8 @@ __lp_floating_scale() {
   # Return $PWD with $HOME at the start replaced by "~".
   if (( _LP_SHELL_zsh )); then
       # Zsh-specific version, use zsh print -D builtin function which support named directories
-      zsh_minor_version=${ZSH_VERSION#*.}
-      zsh_minor_version=${zsh_minor_version%%.*}
       # Print -v was introduced in ZSH 5.3
-      if (( zsh_minor_version >= 3 )); then
+      if _lp_zsh_version_greatereq 5 3; then
           __lp_pwd_tilde() {
               print -v lp_pwd_tilde -n -r -D "${1:-$PWD}"
           }
@@ -1327,7 +1325,7 @@ __lp_floating_scale() {
           }
       fi
   else
-      # Bash-compatible fallback
+      # Bash version
       __lp_pwd_tilde() {
           # Needs to be in a variable, as different versions of Bash treat '~' in a
           # substitution differently

--- a/liquidprompt
+++ b/liquidprompt
@@ -1313,10 +1313,15 @@ __lp_floating_scale() {
 
 # Return $PWD with $HOME at the start replaced by "~".
 __lp_pwd_tilde() {  # [path]
-    # Needs to be in a variable, as different versions of Bash treat '~' in a
-    # substitution differently
-    local _path="${1:-$PWD}" tilde="~"
-    lp_pwd_tilde="${_path/#$HOME/$tilde}"
+    if (( _LP_SHELL_zsh )); then
+        # Use zsh print -D builtin function which support named directories
+        print -v lp_pwd_tilde -n -r -D "${1:-$PWD}"
+    else
+        # Needs to be in a variable, as different versions of Bash treat '~' in a
+        # substitution differently
+        local _path="${1:-$PWD}" tilde="~"
+        lp_pwd_tilde="${_path/#$HOME/$tilde}"
+    fi
 }
 
 # insert a space on the right

--- a/liquidprompt
+++ b/liquidprompt
@@ -1315,7 +1315,13 @@ __lp_floating_scale() {
 __lp_pwd_tilde() {  # [path]
     if (( _LP_SHELL_zsh )); then
         # Use zsh print -D builtin function which support named directories
-        print -v lp_pwd_tilde -n -r -D "${1:-$PWD}"
+        local minor_version=${ZSH_VERSION#*.}
+        local minor_version=${minor_version%%.*}
+        if (( minor_version >= 3 )); then
+            print -v lp_pwd_tilde -n -r -D "${1:-$PWD}"
+        else
+            lp_pwd_tilde=$(print -n -r -D "${1:-$PWD}")
+        fi
     else
         # Needs to be in a variable, as different versions of Bash treat '~' in a
         # substitution differently

--- a/liquidprompt
+++ b/liquidprompt
@@ -1311,24 +1311,30 @@ __lp_floating_scale() {
     ret=$(( integer * $2 + decimal ))
 }
 
-# Return $PWD with $HOME at the start replaced by "~".
-__lp_pwd_tilde() {  # [path]
-    if (( _LP_SHELL_zsh )); then
-        # Use zsh print -D builtin function which support named directories
-        local minor_version=${ZSH_VERSION#*.}
-        local minor_version=${minor_version%%.*}
-        if (( minor_version >= 3 )); then
-            print -v lp_pwd_tilde -n -r -D "${1:-$PWD}"
-        else
-            lp_pwd_tilde=$(print -n -r -D "${1:-$PWD}")
-        fi
-    else
-        # Needs to be in a variable, as different versions of Bash treat '~' in a
-        # substitution differently
-        local _path="${1:-$PWD}" tilde="~"
-        lp_pwd_tilde="${_path/#$HOME/$tilde}"
-    fi
-}
+  # Return $PWD with $HOME at the start replaced by "~".
+  if (( _LP_SHELL_zsh )); then
+      # Zsh-specific version, use zsh print -D builtin function which support named directories
+      zsh_minor_version=${ZSH_VERSION#*.}
+      zsh_minor_version=${zsh_minor_version%%.*}
+      # Print -v was introduced in ZSH 5.3
+      if (( zsh_minor_version >= 3 )); then
+          __lp_pwd_tilde() {
+              print -v lp_pwd_tilde -n -r -D "${1:-$PWD}"
+          }
+      else
+          __lp_pwd_tilde() {
+              lp_pwd_tilde=$(print -n -r -D "${1:-$PWD}")
+          }
+      fi
+  else
+      # Bash-compatible fallback
+      __lp_pwd_tilde() {
+          # Needs to be in a variable, as different versions of Bash treat '~' in a
+          # substitution differently
+          local _path="${1:-$PWD}" tilde="~"
+          lp_pwd_tilde="${_path/#$HOME/$tilde}"
+      }
+  fi
 
 # insert a space on the right
 # Deprecated since v2.0.

--- a/tests/test_utils.sh
+++ b/tests/test_utils.sh
@@ -152,6 +152,23 @@ function test_pwd_tilde {
   assertEquals "shorted home path" "~/a/different/path" "$lp_pwd_tilde"
 }
 
+function test_pwd_tilde_named_directory {
+  # Named directory feature in https://zsh.sourceforge.io/Doc/Release/Expansion.html#Static-named-directories
+  if (( _LP_SHELL_zsh )); then
+      pathSetUp
+      hash -d nd=/tmp/_lp/a/very
+      __lp_pwd_tilde "/tmp/_lp/a/very/"
+      assertEquals "named directory path" "~nd/" "$lp_pwd_tilde"
+
+      hash -d nd=/tmp/_lp/a/very
+      __lp_pwd_tilde "/tmp/_lp/a/very/long/pathname"
+
+      assertEquals "subnamed directory path" "~nd/long/pathname" "$lp_pwd_tilde"
+      pathTearDown
+      hash -d nd=
+  fi
+}
+
 function pathSetUp {
   # We cannot use SHUNIT_TMPDIR because we need to know the start of the path
   typeset long_path="/tmp/_lp/a/very/long/pathname"


### PR DESCRIPTION
Named directory in Zsh allow setting "alias" for directories.

They are set via `hash -d name=/path` and can be used in paths, eg. `cd ~name` or `touch ~name/file`.

In Zsh built-in prompt they are then displayed as `~name`  or `name/subdir`. This pull-request make liquidprompt displays it the same way.

Notes:
- Be careful not to include a terminal '/' when setting the path in the hash command, zsh don't supports it.
- Named directory can be unset via `hash -d=`

Feature is zsh only

Example prompt
```
[:~] % hash -d prj=~/Projects
[:~] % cd ~prj/liquidprompt 
[:~prj/liquidprompt] named-directory-support* ± cd ..
[:~prj] % cd ..
```

# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, ran, and their warnings fixed:
    - [x] unit tests have been updated (see `tests/test_*.sh` files)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh` (requires [shellcheck](https://github.com/koalaman/shellcheck#user-content-installing)).
- documentation have been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: X.Y` or `.. versionchanged:: Y.Z`
    - [x] functions signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh` (requires Python 3 and `requirements.txt`
          installed (`cd docs/; python3 -m venv venv; . venv/bin/activate; pip install -r requirements.txt`))

 `docs/docs-lint.sh` returned an error for `https://dn-works.com/ufas/` but that is not related to my changes

```
(        overview: line  208) broken    https://dn-works.com/ufas/ - HTTPSConnectionPool(host='dn-works.com', port=443): Max retries exceeded with url: /ufas/ (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1000)')))
```
