### PR TITLE
Add Zellij as detected terminal multiplexer

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -460,8 +460,8 @@ Features
    If currently running inside an active multiplexer session, the current
    session is excluded from the count.
 
-   Will be disabled if none of ``screen``, ``shpool``, ``tmux``, or
-   ``herdr`` are found.
+   Will be disabled if none of ``screen``, ``shpool``, ``tmux``,
+   ``herdr``, or ``zellij`` are found.
 
    .. note::
       This can be slow on some machines, and prompt speed can be greatly
@@ -477,8 +477,8 @@ Features
 
    Display the number of detached multiplexer sessions.
 
-   Will be disabled if none of ``screen``, ``shpool``, ``tmux``, or
-   ``herdr`` are found.
+   Will be disabled if none of ``screen``, ``shpool``, ``tmux``,
+   ``herdr``, or ``zellij`` are found.
 
    .. note::
       This can be slow on some machines, and prompt speed can be greatly
@@ -816,7 +816,7 @@ Features
    :value: 1
 
    Allows getting the name of the current multiplexer
-   (*screen*, *shpool*, *tmux*, or *herdr*), if any.
+   (*screen*, *shpool*, *tmux*, *herdr*, or *zellij*), if any.
 
    If set to ``0``, also disables:
 

--- a/docs/functions/data.rst
+++ b/docs/functions/data.rst
@@ -339,6 +339,7 @@ Environment
    * ``screen``
    * ``shpool``
    * ``herdr``
+   * ``zellij``
 
    .. versionadded:: 2.0
 
@@ -348,7 +349,7 @@ Environment
       Return variable renamed from ``lp_mulitplexer`` to ``lp_multiplexer``.
 
    .. versionchanged:: 2.4
-      Added support for ``herdr``.
+      Added support for ``herdr`` and ``zellij``.
 
 .. function:: _lp_shell_level() -> var:lp_shell_level
 
@@ -397,7 +398,7 @@ Jobs
    .. versionadded:: 2.0
 
    .. versionchanged:: 2.4
-      Added support for ``herdr``.
+      Added support for ``herdr`` and ``zellij``.
 
 .. function:: _lp_jobcount() -> var:lp_running_jobs, var:lp_stopped_jobs
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,7 +70,7 @@ they require.
    * Terminal formatting requires ``tput``.
    * Time display requires ``date``.
    * Detached session status looks for ``screen``, ``shpool``, ``tmux``,
-     and/or ``herdr``.
+     ``herdr``, and/or ``zellij``.
    * VCS support features require ``git``, ``hg``, ``svn``, ``bzr`` or
      ``fossil`` for their respective repositories.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -85,7 +85,7 @@ These are some of the most popular features:
   much.
 - **Sudo**: show if the user currently has *sudo* rights.
 - **Multiplexers**: indicate if you are in a terminal multiplexer session
-  (i.e. tmux, screen, shpool, or herdr).
+  (i.e. tmux, screen, shpool, herdr, or zellij).
 - **Proxy**: indicate whether a proxy is configured.
 - **Temperature**: warn if the temperature goes too high.
 - **Hot prompt switch**: commands allowing you to rapidly switch the theme,

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -78,3 +78,4 @@ workspace
 worktree
 worktrees
 zsh
+zellij

--- a/liquidprompt
+++ b/liquidprompt
@@ -1083,11 +1083,12 @@ lp_activate() {
         fi
     fi
 
-    if (( LP_ENABLE_DETACHED_SESSIONS )); then
+    if (( LP_ENABLE_DETACHED_SESSIONS || LP_ENABLE_ATTACHED_SESSIONS )); then
         command -v screen >/dev/null ; _LP_ENABLE_SCREEN=$(( ! $? ))
         command -v tmux >/dev/null   ; _LP_ENABLE_TMUX=$(( ! $? ))
         command -v shpool >/dev/null ; _LP_ENABLE_SHPOOL=$(( ! $? ))
         command -v herdr >/dev/null  ; _LP_ENABLE_HERDR=$(( ! $? ))
+        command -v zellij >/dev/null ; _LP_ENABLE_ZELLIJ=$(( ! $? ))
     fi
 
     # Use standard path symbols inside Midnight Commander
@@ -2205,6 +2206,9 @@ _lp_multiplexer() { # [--internal]
     elif [[ -n ${HERDR_SESSION-} || -n ${HERDR_SESSION_NAME-} || -n ${HERDR_ENV-} ]]; then
         lp_multiplexer=herdr
         return 0
+    elif [[ -n ${ZELLIJ-} || -n ${ZELLIJ_SESSION_NAME-} ]]; then
+        lp_multiplexer=zellij
+        return 0
     fi
     return 1
 }
@@ -2881,7 +2885,7 @@ _lp_shell_level_color() {
 # Related jobs #
 ################
 
-# Return the count of detached screen, tmux, shpool, and herdr sessions.
+# Return the count of detached screen, tmux, shpool, herdr, and zellij sessions.
 _lp_detached_sessions() {
     (( LP_ENABLE_DETACHED_SESSIONS )) || return 2
 
@@ -2890,12 +2894,13 @@ _lp_detached_sessions() {
     (( _LP_ENABLE_TMUX )) && count+=$(tmux list-sessions 2> /dev/null | GREP_OPTIONS='' \grep -cv 'attached')
     (( _LP_ENABLE_SHPOOL )) && count+=$(shpool list 2> /dev/null | GREP_OPTIONS='' \grep -c 'disconnected')
     (( _LP_ENABLE_HERDR )) && count+=$(herdr session list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]detached\([[:space:]]\|$\)')
+    (( _LP_ENABLE_ZELLIJ )) && count+=$(zellij list-sessions -n 2> /dev/null | GREP_OPTIONS='' \grep -vce '(EXITED' -e '(current)' -e '^[[:space:]]*$')
     lp_detached_sessions=$count
 
     (( lp_detached_sessions ))
 }
 
-# Return the count of attached running screen, tmux, shpool, and herdr sessions.
+# Return the count of attached running screen, tmux, shpool, herdr, and zellij sessions.
 _lp_attached_sessions() {
     (( LP_ENABLE_ATTACHED_SESSIONS )) || return 2
 
@@ -2904,6 +2909,7 @@ _lp_attached_sessions() {
     (( _LP_ENABLE_TMUX )) && count+=$(tmux list-sessions 2> /dev/null | GREP_OPTIONS='' \grep -c '(attached)$')
     (( _LP_ENABLE_SHPOOL )) && count+=$(shpool list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]attached$')
     (( _LP_ENABLE_HERDR )) && count+=$(herdr session list 2> /dev/null | GREP_OPTIONS='' \grep -c '[[:space:]]\(running\|attached\)\([[:space:]]\|$\)')
+    (( _LP_ENABLE_ZELLIJ )) && count+=$(zellij list-sessions -n 2> /dev/null | GREP_OPTIONS='' \grep -c '(current)')
 
     if _lp_multiplexer && (( count > 0 )); then
         (( count-- ))

--- a/tests/test_attached_sessions.sh
+++ b/tests/test_attached_sessions.sh
@@ -17,13 +17,14 @@ _LP_ENABLE_SCREEN=1
 _LP_ENABLE_TMUX=1
 _LP_ENABLE_SHPOOL=1
 _LP_ENABLE_HERDR=1
+_LP_ENABLE_ZELLIJ=1
 
 function setUp {
-  unset TMUX SHPOOL_SESSION_NAME HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV
+  unset TMUX SHPOOL_SESSION_NAME HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV ZELLIJ ZELLIJ_SESSION_NAME
   TERM=dumb
 }
 
-typeset -a screen_outputs screen_values shpool_outputs shpool_values tmux_outputs tmux_values herdr_outputs herdr_values
+typeset -a screen_outputs screen_values shpool_outputs shpool_values tmux_outputs tmux_values herdr_outputs herdr_values zellij_outputs zellij_values
 
 # Screen outputs
 screen_outputs+=(
@@ -116,6 +117,40 @@ default              running  /root/.config/herdr                              /
 )
 herdr_values+=(1)
 
+# Zellij outputs
+zellij_outputs+=(
+""
+)
+zellij_values+=(0)
+
+zellij_outputs+=(
+"session1 [Created 10s ago] (current)
+"
+)
+zellij_values+=(1)
+
+zellij_outputs+=(
+"session1 [Created 10s ago]
+"
+)
+zellij_values+=(0)
+
+zellij_outputs+=(
+"session1 [Created 10s ago] (current)
+session2 [Created 5s ago]
+"
+)
+zellij_values+=(1)
+
+zellij_outputs+=(
+"s1 [Created 10s ago] (current)
+s2 [Created 8s ago]
+s3 [Created 5s ago] (current)
+s4 [Created 1s ago] (EXITED - attach to resurrect)
+"
+)
+zellij_values+=(2)
+
 
 function test_screen_attached_sessions {
   screen() {
@@ -124,6 +159,7 @@ function test_screen_attached_sessions {
   shpool() { : ; }
   tmux() { : ; }
   herdr() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#screen_values[@]}; index++ )); do
     __screen_output=${screen_outputs[$index]}
@@ -139,6 +175,7 @@ function test_shpool_attached_sessions {
   screen() { : ; }
   tmux() { : ; }
   herdr() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#shpool_values[@]}; index++ )); do
     __shpool_output=${shpool_outputs[$index]}
@@ -154,6 +191,7 @@ function test_tmux_attached_sessions {
   screen() { : ; }
   shpool() { : ; }
   herdr() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#tmux_values[@]}; index++ )); do
     __tmux_output=${tmux_outputs[$index]}
@@ -169,11 +207,28 @@ function test_herdr_attached_sessions {
   screen() { : ; }
   shpool() { : ; }
   tmux() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#herdr_values[@]}; index++ )); do
     __herdr_output=${herdr_outputs[$index]}
     _lp_attached_sessions
     assertEquals "herdr attached sessions output at index ${index}" "${herdr_values[$index]}" "$lp_attached_sessions"
+  done
+}
+
+function test_zellij_attached_sessions {
+  zellij() {
+    printf '%s' "$__zellij_output"
+  }
+  screen() { : ; }
+  shpool() { : ; }
+  tmux() { : ; }
+  herdr() { : ; }
+
+  for (( index=0; index < ${#zellij_values[@]}; index++ )); do
+    __zellij_output=${zellij_outputs[$index]}
+    _lp_attached_sessions
+    assertEquals "zellij attached sessions output at index ${index}" "${zellij_values[$index]}" "$lp_attached_sessions"
   done
 }
 
@@ -187,6 +242,7 @@ main   running
 sub    detached
 "
   }
+  zellij() { : ; }
   LP_COLOR_JOB_D="[D]"
   LP_COLOR_JOB_A="[A]"
   NO_COL=""
@@ -195,6 +251,9 @@ sub    detached
 }
 
 function test_attached_sessions_exclude_current {
+  local -i total_sessions=10
+  local -i inside_sessions=$(( total_sessions - 1 ))
+
   tmux() {
     printf '%s' "0: 1 windows [179x96] (attached)
 1: 1 windows [179x96] (attached)
@@ -216,40 +275,51 @@ h1     attached
 h2     attached
 "
   }
+  zellij() {
+    printf '%s' "z1 (current)
+z2 (current)
+"
+  }
 
-  # 1. Inside tmux (subtract 1)
+  # Inside tmux (subtract 1)
   TMUX=1
   _lp_attached_sessions
-  assertEquals "Exclude current session inside tmux" "7" "$lp_attached_sessions"
+  assertEquals "Exclude current session inside tmux" "$inside_sessions" "$lp_attached_sessions"
 
-  # 2. Inside screen (subtract 1)
+  # Inside screen (subtract 1)
   unset TMUX
   TERM=screen-256color
   _lp_attached_sessions
-  assertEquals "Exclude current session inside screen" "7" "$lp_attached_sessions"
+  assertEquals "Exclude current session inside screen" "$inside_sessions" "$lp_attached_sessions"
 
-  # 3. Inside shpool (subtract 1)
+  # Inside shpool (subtract 1)
   TERM=dumb
   SHPOOL_SESSION_NAME=s1
   _lp_attached_sessions
-  assertEquals "Exclude current session inside shpool" "7" "$lp_attached_sessions"
+  assertEquals "Exclude current session inside shpool" "$inside_sessions" "$lp_attached_sessions"
 
-  # 4. Inside herdr (subtract 1)
+  # Inside herdr (subtract 1)
   unset SHPOOL_SESSION_NAME
   HERDR_SESSION=h1
   _lp_attached_sessions
-  assertEquals "Exclude current session inside herdr" "7" "$lp_attached_sessions"
+  assertEquals "Exclude current session inside herdr" "$inside_sessions" "$lp_attached_sessions"
 
-  # 5. Outside any multiplexer (do not subtract)
+  # Inside zellij (subtract 1)
   unset HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV
+  ZELLIJ=1
   _lp_attached_sessions
-  assertEquals "Do not exclude current session when outside multiplexer" "8" "$lp_attached_sessions"
+  assertEquals "Exclude current session inside zellij" "$inside_sessions" "$lp_attached_sessions"
 
-  # 6. Inside tmux but LP_ENABLE_MULTIPLEXER=0 (multiplexer detection disabled, do not subtract)
-  TMUX=1
+  # Outside any multiplexer (do not subtract)
+  unset ZELLIJ ZELLIJ_SESSION_NAME
+  _lp_attached_sessions
+  assertEquals "Do not exclude current session when outside multiplexer" "$total_sessions" "$lp_attached_sessions"
+
+  # Inside zellij but LP_ENABLE_MULTIPLEXER=0 (multiplexer detection disabled, do not subtract)
+  ZELLIJ=1
   LP_ENABLE_MULTIPLEXER=0
   _lp_attached_sessions
-  assertEquals "Do not exclude current session when LP_ENABLE_MULTIPLEXER=0" "8" "$lp_attached_sessions"
+  assertEquals "Do not exclude current session when LP_ENABLE_MULTIPLEXER=0" "$total_sessions" "$lp_attached_sessions"
   LP_ENABLE_MULTIPLEXER=1
 }
 

--- a/tests/test_detached_sessions.sh
+++ b/tests/test_detached_sessions.sh
@@ -14,9 +14,10 @@ _LP_ENABLE_SCREEN=1
 _LP_ENABLE_TMUX=1
 _LP_ENABLE_SHPOOL=1
 _LP_ENABLE_HERDR=1
-unset HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV
+_LP_ENABLE_ZELLIJ=1
+unset HERDR_SESSION HERDR_SESSION_NAME HERDR_ENV ZELLIJ ZELLIJ_SESSION_NAME
 
-typeset -a screen_outputs screen_values shpool_outputs shpool_values tmux_outputs tmux_values herdr_outputs herdr_values
+typeset -a screen_outputs screen_values shpool_outputs shpool_values tmux_outputs tmux_values herdr_outputs herdr_values zellij_outputs zellij_values
 
 # Add test cases to these arrays like below
 
@@ -104,6 +105,46 @@ main   detached
 )
 herdr_values+=(1)
 
+# Zellij outputs
+zellij_outputs+=(
+""
+)
+zellij_values+=(0)
+
+zellij_outputs+=(
+"session1 [Created 10s ago] (current)
+"
+)
+zellij_values+=(0)
+
+zellij_outputs+=(
+"session1 [Created 10s ago]
+"
+)
+zellij_values+=(1)
+
+zellij_outputs+=(
+"session1 [Created 10s ago] (current)
+session2 [Created 5s ago]
+"
+)
+zellij_values+=(1)
+
+zellij_outputs+=(
+"session1 [Created 10s ago] (EXITED - attach to resurrect)
+"
+)
+zellij_values+=(0)
+
+zellij_outputs+=(
+"s1 [Created 10s ago] (current)
+s2 [Created 8s ago]
+s3 [Created 5s ago]
+s4 [Created 1s ago] (EXITED - attach to resurrect)
+"
+)
+zellij_values+=(2)
+
 
 function test_screen_sessions {
 
@@ -113,6 +154,7 @@ function test_screen_sessions {
   shpool() { : ; }
   tmux() { : ; }
   herdr() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#screen_values[@]}; index++ )); do
     __screen_output=${screen_outputs[$index]}
@@ -129,6 +171,7 @@ function test_shpool_sessions {
   screen() { : ; }
   tmux() { : ; }
   herdr() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#shpool_values[@]}; index++ )); do
     __shpool_output=${shpool_outputs[$index]}
@@ -145,6 +188,7 @@ function test_tmux_sessions {
   screen() { : ; }
   shpool() { : ; }
   herdr() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#tmux_values[@]}; index++ )); do
     __tmux_output=${tmux_outputs[$index]}
@@ -161,6 +205,7 @@ function test_herdr_sessions {
   screen() { : ; }
   shpool() { : ; }
   tmux() { : ; }
+  zellij() { : ; }
 
   for (( index=0; index < ${#herdr_values[@]}; index++ )); do
     __herdr_output=${herdr_outputs[$index]}
@@ -180,9 +225,27 @@ sub    detached
   screen() { : ; }
   shpool() { : ; }
   tmux() { : ; }
+  zellij() { : ; }
 
   _lp_detached_sessions
   assertEquals "herdr detached sessions count" "1" "$lp_detached_sessions"
+}
+
+function test_zellij_sessions {
+
+  zellij() {
+    printf '%s' "$__zellij_output"
+  }
+  screen() { : ; }
+  shpool() { : ; }
+  tmux() { : ; }
+  herdr() { : ; }
+
+  for (( index=0; index < ${#zellij_values[@]}; index++ )); do
+    __zellij_output=${zellij_outputs[$index]}
+    _lp_detached_sessions
+    assertEquals "zellij sessions output at index ${index}" "${zellij_values[$index]}" "$lp_detached_sessions"
+  done
 }
 
 . ./shunit2


### PR DESCRIPTION
## Description

This PR adds support for **Zellij** (https://zellij.dev) as a detected terminal multiplexer, alongside `screen`, `tmux`, `shpool`, and `herdr`.

### Changes Included:
1. **Environment Detection:** Added Zellij detection to `_lp_multiplexer()` via `$ZELLIJ` and `$ZELLIJ_SESSION_NAME`.
2. **Session Counting:** Added Zellij parsing to `_lp_detached_sessions()` and `_lp_attached_sessions()` using `zellij list-sessions -n`.
3. **Session Exclusion:** Excludes current session context by default when running inside Zellij.
4. **Init Guard Fix:** Fixed guard in `__lp_post_source_config()` to check `(( LP_ENABLE_DETACHED_SESSIONS || LP_ENABLE_ATTACHED_SESSIONS ))` so attached session tracking works even if detached tracking is disabled.
5. **Documentation & Tests:** Updated all docs, wordlists, and unit test suites.

# Technical checklist:

- code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] printing a "%" character is done with `_LP_PERCENT`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible
    - [x] string substitutions may be done differently in Bash and Zsh (use `_LP_SHELL_*`)
- tests and checks have been added, run, and their warnings fixed:
    - [x] unit tests have been updated (`tests/test_detached_sessions.sh`, `tests/test_attached_sessions.sh`)
    - [x] ran `tests.sh`
    - [x] ran `shellcheck.sh`
- documentation has been updated accordingly:
    - [x] functions and attributes are documented in alphabetical order
    - [x] new sections are documented in the default theme
    - [x] tag `.. versionadded:: 2.4` / `.. versionchanged:: 2.4`
    - [x] function signatures have arguments, returned code, and set value(s)
    - [x] attributes have types and defaults
    - [x] ran `docs/docs-lint.sh`