### PR TITLE
Add LP_ENABLE_VCS_RESOLVE_SYMLINKS config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in path. ([#858])
 - **path**: `LP_PATH_METHOD` supports more than one method at once ([#761])
 - **title**: `LP_ENABLE_TITLE_COMMAND_ONLY` config option ([#864])
-- **vcs**: `LP_ENABLE_VCS_RESOLVE_SYMLINKS` config option to resolve symbolic links when searching for repositories
+- **vcs**: `LP_ENABLE_VCS_RESOLVE_SYMLINKS` config option to resolve symbolic links when searching for repositories ([#873])
 
 ### Fixed
 - **general**: Unset deprecated variable access ([63a0408])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in path. ([#858])
 - **path**: `LP_PATH_METHOD` supports more than one method at once ([#761])
 - **title**: `LP_ENABLE_TITLE_COMMAND_ONLY` config option ([#864])
+- **vcs**: `LP_ENABLE_VCS_RESOLVE_SYMLINKS` config option to resolve symbolic links when searching for repositories
 
 ### Fixed
 - **general**: Unset deprecated variable access ([63a0408])

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1204,6 +1204,19 @@ Features
 
    .. versionadded:: 2.2
 
+.. attribute:: LP_ENABLE_VCS_RESOLVE_SYMLINKS
+   :type: bool
+   :value: 0
+
+   Resolve symbolic links when searching for VCS repositories.
+
+   If enabled, Liquid Prompt will search the physical directory hierarchy
+   if no VCS repository is found in the logical path hierarchy. This allows
+   VCS information (such as Git branch, dirty status, stashes) to be displayed
+   when navigating into symlinked subdirectories within a repository.
+
+   .. versionadded:: 2.3
+
 .. attribute:: LP_ENABLE_VCS_ROOT
    :type: bool
    :value: 0

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1213,9 +1213,9 @@ Features
    If enabled, Liquid Prompt will search the physical directory hierarchy
    if no VCS repository is found in the logical path hierarchy. This allows
    VCS information (such as Git branch, dirty status, stashes) to be displayed
-   when navigating into symlinked subdirectories within a repository.
+   when navigating into a symbolic link to a repository subdirectory.
 
-   .. versionadded:: 2.3
+   .. versionadded:: 2.4
 
 .. attribute:: LP_ENABLE_VCS_ROOT
    :type: bool

--- a/docs/functions/data/vcs.rst
+++ b/docs/functions/data/vcs.rst
@@ -65,6 +65,9 @@ this.
    .. versionchanged:: 2.2
       Added the *lp_vcs_specific_dir* return value.
 
+   .. versionchanged:: 2.3
+      Added support for resolving symbolic links via :attr:`LP_ENABLE_VCS_RESOLVE_SYMLINKS`.
+
 .. function:: _lp_are_vcs_enabled()
 
    Returns ``true`` if the current directory is not excluded by the config

--- a/docs/functions/data/vcs.rst
+++ b/docs/functions/data/vcs.rst
@@ -15,7 +15,7 @@ a theme can provide a common look for all VCS types.
 See the default theme function :func:`_lp_vcs_details_color` for an example of
 this.
 
-.. function:: _lp_find_vcs() -> var:lp_vcs_type, var:lp_vcs_root, \
+.. function:: _lp_find_vcs([directory]) -> var:lp_vcs_type, var:lp_vcs_root, \
    var:lp_vcs_dir, var:lp_vcs_specific_dir, var:lp_vcs_subtype
 
    Returns ``true`` if the current directory is part of a version control
@@ -65,10 +65,11 @@ this.
    .. versionchanged:: 2.2
       Added the *lp_vcs_specific_dir* return value.
 
-   .. versionchanged:: 2.3
-      Added support for resolving symbolic links via :attr:`LP_ENABLE_VCS_RESOLVE_SYMLINKS`.
+   .. versionchanged:: 2.4
+      Added support for resolving symbolic links via
+      :attr:`LP_ENABLE_VCS_RESOLVE_SYMLINKS`.
 
-.. function:: _lp_are_vcs_enabled()
+.. function:: _lp_are_vcs_enabled([directory])
 
    Returns ``true`` if the current directory is not excluded by the config
    option :attr:`LP_DISABLED_VCS_PATHS`.

--- a/liquidprompt
+++ b/liquidprompt
@@ -1352,9 +1352,13 @@ __lp_floating_scale() {
           lp_pwd_tilde="${_path/#$HOME/$tilde}"
       }
 
-      __lp_physical_pwd() {
-          lp_physical_pwd="$(pwd -P 2>/dev/null)"
-      }
+      if _lp_bash_version_greatereq 5 3; then
+          eval '__lp_physical_pwd() { lp_physical_pwd=${ pwd -P ; }; }'
+      else
+          __lp_physical_pwd() {
+              lp_physical_pwd="$(pwd -P 2>/dev/null)"
+          }
+      fi
   fi
 
 # insert a space on the right
@@ -2988,8 +2992,9 @@ _lp_are_vcs_enabled() {
 
 # Search upwards through a directory structure looking for a sign of a VCS
 # repository. Used to avoid invoking VCS binaries to discover if in a repo.
-_lp_find_vcs() {
-    if ! _lp_are_vcs_enabled; then
+_lp_find_vcs() {  # [directory]
+    local search_path="${1:-$PWD}"
+    if ! _lp_are_vcs_enabled "$search_path"; then
         lp_vcs_type="disabled"
         lp_vcs_root=""
         return 2
@@ -3006,51 +3011,30 @@ _lp_find_vcs() {
     fi
 
     if [[ -z $lp_vcs_type ]]; then
-        local vcs search_path="$PWD" checked_physical=0
-
-        while true; do
-            lp_vcs_root="$search_path"
-            while [[ -n "$lp_vcs_root" ]]; do
-                for vcs in ${_LP_ENABLED_VCSS[@]+"${_LP_ENABLED_VCSS[@]}"}; do
-                    lp_vcs_dir="$lp_vcs_root/.$vcs"
-                    if [[ -d "$lp_vcs_dir" ]]; then
-                        lp_vcs_type="$vcs"
-                        break 2
-                    fi
-                done
-                unset lp_vcs_dir
-
-                if (( LP_ENABLE_GIT )) && [[ -f "$lp_vcs_root/.git" ]]; then
-                    lp_vcs_type="git"
-                    lp_vcs_dir="$(\git rev-parse --git-dir 2>/dev/null)"
-                    break
+        local vcs
+        lp_vcs_root="$search_path"
+        while [[ -n "$lp_vcs_root" ]]; do
+            for vcs in ${_LP_ENABLED_VCSS[@]+"${_LP_ENABLED_VCSS[@]}"}; do
+                lp_vcs_dir="$lp_vcs_root/.$vcs"
+                if [[ -d "$lp_vcs_dir" ]]; then
+                    lp_vcs_type="$vcs"
+                    break 2
                 fi
-
-                if (( LP_ENABLE_FOSSIL )) && [[ -f "$lp_vcs_root/_FOSSIL_" || -f "$lp_vcs_root/.fslckout" ]]; then
-                    lp_vcs_type="fossil"
-                    return 0
-                fi
-
-                lp_vcs_root="${lp_vcs_root%/*}"
             done
+            unset lp_vcs_dir
 
-            if [[ -n "$lp_vcs_type" ]] || (( ! LP_ENABLE_VCS_RESOLVE_SYMLINKS )) || (( checked_physical )); then
+            if (( LP_ENABLE_GIT )) && [[ -f "$lp_vcs_root/.git" ]]; then
+                lp_vcs_type="git"
+                lp_vcs_dir="$(\git rev-parse --git-dir 2>/dev/null)"
                 break
             fi
 
-            local lp_physical_pwd
-            __lp_physical_pwd
-            if [[ -n "$lp_physical_pwd" && "$lp_physical_pwd" != "$search_path" ]]; then
-                if ! _lp_are_vcs_enabled "$lp_physical_pwd"; then
-                    lp_vcs_type="disabled"
-                    lp_vcs_root=""
-                    return 2
-                fi
-                search_path="$lp_physical_pwd"
-                checked_physical=1
-            else
-                break
+            if (( LP_ENABLE_FOSSIL )) && [[ -f "$lp_vcs_root/_FOSSIL_" || -f "$lp_vcs_root/.fslckout" ]]; then
+                lp_vcs_type="fossil"
+                return 0
             fi
+
+            lp_vcs_root="${lp_vcs_root%/*}"
         done
     fi
 
@@ -3067,6 +3051,16 @@ _lp_find_vcs() {
             lp_vcs_subtype="svn"
         else
             lp_vcs_subtype=""
+        fi
+    fi
+
+    # Add the $1 check to prevent double checking for symlinks.
+    if [[ -z "$lp_vcs_type" && -z "${1-}" ]] && (( LP_ENABLE_VCS_RESOLVE_SYMLINKS )); then
+        local lp_physical_pwd
+        __lp_physical_pwd
+        if [[ -n "$lp_physical_pwd" && "$lp_physical_pwd" != "$search_path" ]]; then
+            _lp_find_vcs "$lp_physical_pwd"
+            return "$?"
         fi
     fi
 

--- a/liquidprompt
+++ b/liquidprompt
@@ -643,6 +643,7 @@ __lp_source_config() {
     LP_ENABLE_BZR=${LP_ENABLE_BZR:-1}
     LP_ENABLE_VCS_LINES=${LP_ENABLE_VCS_LINES:-1}
     LP_ENABLE_VCS_REMOTE=${LP_ENABLE_VCS_REMOTE:-0}
+    LP_ENABLE_VCS_RESOLVE_SYMLINKS=${LP_ENABLE_VCS_RESOLVE_SYMLINKS:-0}
     LP_ENABLE_TIME=${LP_ENABLE_TIME:-0}
     LP_TIME_ANALOG=${LP_TIME_ANALOG:-0}
     LP_ENABLE_RUNTIME=${LP_ENABLE_RUNTIME:-1}
@@ -1338,6 +1339,10 @@ __lp_floating_scale() {
               lp_pwd_tilde=$(print -n -r -D "${1:-$PWD}")
           }
       fi
+
+      __lp_physical_pwd() {
+          lp_physical_pwd="${PWD:A}"
+      }
   else
       # Bash version
       __lp_pwd_tilde() {
@@ -1345,6 +1350,10 @@ __lp_floating_scale() {
           # substitution differently
           local _path="${1:-$PWD}" tilde="~"
           lp_pwd_tilde="${_path/#$HOME/$tilde}"
+      }
+
+      __lp_physical_pwd() {
+          lp_physical_pwd="$(pwd -P 2>/dev/null)"
       }
   fi
 
@@ -2968,9 +2977,9 @@ _lp_jobcount_color() {
 ######################
 
 _lp_are_vcs_enabled() {
-    local _path
+    local _path _current="${1:-$PWD}"
     for _path in ${LP_DISABLED_VCS_PATHS[@]+"${LP_DISABLED_VCS_PATHS[@]}"}; do
-        if [[ -n "$_path" && "$PWD" == "$_path"* ]]; then
+        if [[ -n "$_path" && "$_current" == "$_path"* ]]; then
             return 1
         fi
     done
@@ -2997,30 +3006,51 @@ _lp_find_vcs() {
     fi
 
     if [[ -z $lp_vcs_type ]]; then
-        local vcs
-        lp_vcs_root="$PWD"
-        while [[ -n "$lp_vcs_root" ]]; do
-            for vcs in ${_LP_ENABLED_VCSS[@]+"${_LP_ENABLED_VCSS[@]}"}; do
-                lp_vcs_dir="$lp_vcs_root/.$vcs"
-                if [[ -d "$lp_vcs_dir" ]]; then
-                    lp_vcs_type="$vcs"
-                    break 2
-                fi
-            done
-            unset lp_vcs_dir
+        local vcs search_path="$PWD" checked_physical=0
 
-            if (( LP_ENABLE_GIT )) && [[ -f "$lp_vcs_root/.git" ]]; then
-                lp_vcs_type="git"
-                lp_vcs_dir="$(\git rev-parse --git-dir 2>/dev/null)"
+        while true; do
+            lp_vcs_root="$search_path"
+            while [[ -n "$lp_vcs_root" ]]; do
+                for vcs in ${_LP_ENABLED_VCSS[@]+"${_LP_ENABLED_VCSS[@]}"}; do
+                    lp_vcs_dir="$lp_vcs_root/.$vcs"
+                    if [[ -d "$lp_vcs_dir" ]]; then
+                        lp_vcs_type="$vcs"
+                        break 2
+                    fi
+                done
+                unset lp_vcs_dir
+
+                if (( LP_ENABLE_GIT )) && [[ -f "$lp_vcs_root/.git" ]]; then
+                    lp_vcs_type="git"
+                    lp_vcs_dir="$(\git rev-parse --git-dir 2>/dev/null)"
+                    break
+                fi
+
+                if (( LP_ENABLE_FOSSIL )) && [[ -f "$lp_vcs_root/_FOSSIL_" || -f "$lp_vcs_root/.fslckout" ]]; then
+                    lp_vcs_type="fossil"
+                    return 0
+                fi
+
+                lp_vcs_root="${lp_vcs_root%/*}"
+            done
+
+            if [[ -n "$lp_vcs_type" ]] || (( ! LP_ENABLE_VCS_RESOLVE_SYMLINKS )) || (( checked_physical )); then
                 break
             fi
 
-            if (( LP_ENABLE_FOSSIL )) && [[ -f "$lp_vcs_root/_FOSSIL_" || -f "$lp_vcs_root/.fslckout" ]]; then
-                lp_vcs_type="fossil"
-                return 0
+            local lp_physical_pwd
+            __lp_physical_pwd
+            if [[ -n "$lp_physical_pwd" && "$lp_physical_pwd" != "$search_path" ]]; then
+                if ! _lp_are_vcs_enabled "$lp_physical_pwd"; then
+                    lp_vcs_type="disabled"
+                    lp_vcs_root=""
+                    return 2
+                fi
+                search_path="$lp_physical_pwd"
+                checked_physical=1
+            else
+                break
             fi
-
-            lp_vcs_root="${lp_vcs_root%/*}"
         done
     fi
 

--- a/tests/test_git.sh
+++ b/tests/test_git.sh
@@ -75,4 +75,72 @@ function test_git {
     assertEquals "Remote foo is found." "foo" "$lp_vcs_remote"
 }
 
+function test_git_symlinks {
+    LP_ENABLE_GIT=1
+    LP_ENABLE_FOSSIL=0
+    LP_ENABLE_SVN=0
+    LP_ENABLE_BZR=0
+    LP_ENABLE_VCS_ROOT=1
+    LP_ENABLE_VCS_REMOTE=0
+    _LP_GITSTATUS_DATA=0
+
+    lp_activate
+
+    repo_dir="${SHUNIT_TMPDIR}/symlink_repo"
+    mkdir -p "${repo_dir}/subdir"
+    cd "$repo_dir"
+
+    git init -q
+    git config --local user.email "author@example.com"
+    git config --local user.name "A U Thor"
+    touch test.txt
+    git add test.txt
+    git commit -q -m "initial commit" --no-verify --no-gpg-sign
+    git branch -m main
+
+    outside_dir="${SHUNIT_TMPDIR}/outside"
+    mkdir -p "$outside_dir"
+    ln -s "${repo_dir}" "${outside_dir}/link_to_repo"
+    ln -s "${repo_dir}/subdir" "${outside_dir}/link_to_sub"
+
+    # Test 1: Symlink pointing directly to repo root works even without LP_ENABLE_VCS_RESOLVE_SYMLINKS
+    cd "${outside_dir}/link_to_repo"
+    LP_ENABLE_VCS_RESOLVE_SYMLINKS=0
+    _lp_find_vcs
+    assertTrue "Direct symlink to repo root detects VCS." "$?"
+    assertEquals "git" "$lp_vcs_type"
+
+    # Test 2: Symlink to subdirectory fails when LP_ENABLE_VCS_RESOLVE_SYMLINKS=0
+    cd "${outside_dir}/link_to_sub"
+    LP_ENABLE_VCS_RESOLVE_SYMLINKS=0
+    _lp_find_vcs
+    assertFalse "Symlinked subdir should not detect VCS when resolution is disabled." "$?"
+
+    # Test 3: Symlink to subdirectory succeeds when LP_ENABLE_VCS_RESOLVE_SYMLINKS=1
+    cd "${outside_dir}/link_to_sub"
+    LP_ENABLE_VCS_RESOLVE_SYMLINKS=1
+    _lp_find_vcs
+    assertTrue "Symlinked subdir detects VCS when LP_ENABLE_VCS_RESOLVE_SYMLINKS=1." "$?"
+    assertEquals "git" "$lp_vcs_type"
+    _lp_vcs_branch
+    assertEquals "Branch detected in symlinked subdir." "main" "$lp_vcs_branch"
+
+    # Test 4: Symlinked subdirectory respects LP_DISABLED_VCS_PATHS on physical path
+    cd "${outside_dir}/link_to_sub"
+    LP_ENABLE_VCS_RESOLVE_SYMLINKS=1
+    LP_DISABLED_VCS_PATHS=("${repo_dir}")
+    _lp_find_vcs
+    assertEquals "Returns code 2 when physical target is disabled." "2" "$?"
+    assertEquals "VCS type is set to disabled for physical target." "disabled" "$lp_vcs_type"
+
+    # Test 5: Symlinked subdirectory respects LP_DISABLED_VCS_PATHS on logical path
+    cd "${outside_dir}/link_to_sub"
+    LP_ENABLE_VCS_RESOLVE_SYMLINKS=1
+    LP_DISABLED_VCS_PATHS=("${outside_dir}")
+    _lp_find_vcs
+    assertEquals "Returns code 2 when logical symlink path is disabled." "2" "$?"
+    assertEquals "VCS type is set to disabled for logical path." "disabled" "$lp_vcs_type"
+    LP_DISABLED_VCS_PATHS=()
+}
+
 . ./shunit2


### PR DESCRIPTION
# Add `LP_ENABLE_VCS_RESOLVE_SYMLINKS` option to detect VCS repositories in symlinked subdirectories

## Summary

When navigating into a subdirectory of a VCS repository via a symbolic link (for example, `~/frontend -> /projects/my-app/src/components`), Liquid Prompt would fail to detect the repository because the upward directory traversal in `_lp_find_vcs()` only climbed the logical parent paths in `$PWD` (`/home/user/frontend` -> `/home/user` -> `/home` -> `/`).

This PR adds the configuration option **`LP_ENABLE_VCS_RESOLVE_SYMLINKS`** (default: `0` / disabled for backwards compatibility and zero performance regression) to optionally search the physical directory hierarchy when the logical search finds no repository.

---

## Key Design Principles

1. **Fast-path first (Zero overhead):**
   - The primary check always runs against logical `$PWD`.
   - If `LP_ENABLE_VCS_RESOLVE_SYMLINKS=0` (default) or when `$PWD` is already inside a VCS repository, symlink resolution is never invoked and no subshells or extra directory climbs occur.
2. **Shell-native path resolution (0 subshells on modern shells):**
   - In **Zsh**: Uses parameter expansion `${PWD:A}` to resolve the canonical physical path in memory (**0 forks / 0 subshells**).
   - In **Bash 5.3+**: Uses non-subshell in-process command substitution `${ pwd -P ; }` (**0 forks / 0 subshells**).
   - In **Bash 3.2 – 5.2**: Safely falls back to the shell builtin `$(pwd -P 2>/dev/null)`.
3. **Clean, bounded resolution structure:**
   - `_lp_find_vcs([directory])` accepts an optional directory argument and delegates to a strictly bounded 1-level recursive fallback (`_lp_find_vcs "$lp_physical_pwd"`), keeping the primary directory climbing loop untouched and un-nested.
4. **Multi-VCS compatibility:**
   - Implemented within the generic `_lp_find_vcs()` traversal loop, automatically benefiting Git, Subversion, Mercurial, Bazaar, and Fossil.
5. **Integration with `LP_DISABLED_VCS_PATHS`:**
   - Evaluates both the logical symlink path and the physical repository target, ensuring excluded paths return exit code `2` (`lp_vcs_type="disabled"`).
6. **Display context preserved:**
   - The prompt directory segment retains the logical path (`~/frontend`) while the VCS segment accurately displays branch, dirty status, ahead/behind counts, stashes, and marks from the physical repository.

---

## Technical Checklist

- [x] code follows our [shell standards](https://github.com/liquidprompt/liquidprompt/wiki/Shell-standards):
    - [x] correct use of `IFS`
    - [x] careful quoting
    - [x] cautious array access (`${_LP_ENABLED_VCSS[@]+"${_LP_ENABLED_VCSS[@]}"}`, `${LP_DISABLED_VCS_PATHS[@]+"${LP_DISABLED_VCS_PATHS[@]}"}`)
    - [x] portable array indexing with `_LP_FIRST_INDEX`
    - [x] functions/variable naming conventions
    - [x] functions have local variables
    - [x] data functions have optimization guards (early exits)
    - [x] subshells are avoided as much as possible (0 subshells on Zsh and Bash 5.3+)
    - [x] string substitutions handled per shell (`_LP_SHELL_*`)
- [x] tests and checks have been added, run, and their warnings fixed:
    - [x] unit tests updated in `tests/test_git.sh` (`test_git_symlinks`)
    - [x] ran `tests.sh` under Bash and Zsh
    - [x] tested in isolated Fedora 44 container environment with Git, SVN, and Mercurial
- [x] documentation has been updated accordingly:
    - [x] `LP_ENABLE_VCS_RESOLVE_SYMLINKS` documented in alphabetical order in `docs/config.rst`
    - [x] tags `.. versionadded:: 2.4` and `.. versionchanged:: 2.4` added
    - [x] attributes have types and defaults
    - [x] verified with `tools/config-from-doc.sh`
    - [x] verified with Sphinx build & spellcheck (`docs/docs-lint.sh`)
    - [x] entry added to `CHANGELOG.md`